### PR TITLE
[faasr_init_log_folder/FaaSr.schema.json] Create a Log folder name for schema and parse it

### DIFF
--- a/R/faasr_init_log_folder.R
+++ b/R/faasr_init_log_folder.R
@@ -31,6 +31,11 @@ faasr_init_log_folder <- function(faasr) {
 	  region=target_s3$Region
 	)
   )
+  
+  #If user didn't set FaaSrLog name, set it as a default, "FaaSrLog" 
+  if (length(faasr$FaaSrLog)==0){
+    faasr$FaaSrLog <- "FaaSrLog"
+  } 
 
   idfolder <- paste0(faasr$FaaSrLog,"/" ,faasr$InvocationID, "/")
 

--- a/schema/FaaSr.schema.json
+++ b/schema/FaaSr.schema.json
@@ -20,6 +20,11 @@
       "type": "string",
       "minLength": 1
     },
+    "FaaSrLog": {
+      "description": "The name of the Log file's folder",
+      "type": "string",
+      "minLength": 1
+    },
     "FunctionList": {
       "description": "A list of one or more functions that describes the workflow",
       "type": "object",
@@ -145,5 +150,5 @@
         }
     }
   },
-  "required": [ "FunctionInvoke", "LoggingServer", "FunctionList", "ComputeServers", "DataStores", "ActionContainers"]
+  "required": [ "FunctionInvoke", "LoggingServer", "FunctionList", "ComputeServers", "DataStores"]
 }


### PR DESCRIPTION
[faasr_init_log_folder] To set up default log folder as "FaaSrLog" if the user didn't set it.
[FaaSr.schema.json] Add the "FaaSrLog" contents to the schema
** Set ActionContainers optional 