### PR TITLE
[faasr_start] FaaSr library is using itself

### DIFF
--- a/R/faasr_start.R
+++ b/R/faasr_start.R
@@ -23,7 +23,6 @@
 #' @param faasr_payload JSON Payload provided upon Action invocation by the FaaS platform
 
 library("paws")
-library("FaaSr")
 
 faasr_start <- function(faasr_payload) {
 


### PR DESCRIPTION
[faasr_start] Remove library("FaaSr")
** faasr_start in FaaSr library has library("FaaSr"), and it makes an error.
