### PR TITLE
[Rcodes] #1 Standardize msg/cat/log , #2 Get rid of "msg", #3 Raise the random number scale.

### DIFF
--- a/R/faasr_abort_on_multiple_invocations.R
+++ b/R/faasr_abort_on_multiple_invocations.R
@@ -38,8 +38,9 @@ faasr_abort_on_multiple_invocations <- function(faasr, pre) {
     # if object exists, do nothing.
     # if object doesn't exist, leave a log that this function should wait and will be discarded
     if (length(check_fn_done$Contents) == 0){
-      cat('{\"msg\":\"faasr_abort_on_multiple_invocations: not the last trigger invoked - no flag\"}', "\n")
-      faasr_log(faasr, "faasr_abort_on_multiple_invocations: not the last trigger invoked - no flag")
+      res_msg <- paste0('{\"faasr_abort_on_multiple_invocations\":\"not the last trigger invoked - no flag\"}', "\n")
+      cat(res_msg)
+      faasr_log(faasr, res_msg)
       stop()
     }
   }
@@ -94,8 +95,9 @@ faasr_abort_on_multiple_invocations <- function(faasr, pre) {
   if (as.character(random_number) == readLines(func_candidate,1)) {
     NULL
   } else {
-    cat('{\"msg\":\"faasr_abort_on_multiple_invocations: not the last trigger invoked - random number does not match\"}', "\n")
-    faasr_log(faasr, "faasr_abort_on_multiple_invocations: not the last trigger invoked - random number does not match")
+    res_msg <- paste0('{\"faasr_abort_on_multiple_invocations\":\"not the last trigger invoked - random number does not match\"}', "\n"
+    cat(res_msg)
+    faasr_log(faasr, res_msg)
     stop()
   }
 }

--- a/R/faasr_abort_on_multiple_invocations.R
+++ b/R/faasr_abort_on_multiple_invocations.R
@@ -46,7 +46,7 @@ faasr_abort_on_multiple_invocations <- function(faasr, pre) {
   }
 
   # generate random number to be appended to a file named "$FunctionInvoke.candidate"
-  random_number <- sample(1:10000, 1)
+  random_number <- sample(1:10000000, 1)
 
   # Check whether local directory exists, if not, create one.
   if (!dir.exists(id_folder)) {

--- a/R/faasr_check_workflow_cycle.R
+++ b/R/faasr_check_workflow_cycle.R
@@ -22,7 +22,7 @@ faasr_check_workflow_cycle <- function(faasr){
 
     # find target in the graph's successor. If it matches, there's a loop
     if (target %in% graph[[start]]) {
-	  err_msg <- paste0('{\"msg\":\"faasr_check_workflow_cycle: function loop found in ',target,'\"}', "\n")
+	  err_msg <- paste0('{\"faasr_check_workflow_cycle\":\"function loop found in ',target,'\"}', "\n")
 	  cat(err_msg)
 	  faasr_log(faasr, err_msg)
 	  stop()

--- a/R/faasr_get_file.R
+++ b/R/faasr_get_file.R
@@ -15,7 +15,7 @@ faasr_get_file <- function(faasr, server_name, remote_folder, remote_file, local
   if (server_name %in% names(faasr$DataStores)) {
     NULL
    } else {
-     cat('{\"msg\":\"faasr_get_file: Invalid data server name: ',server_name,'\"}', "\n")
+     cat('{\"faasr_get_file\":\"Invalid data server name: ',server_name,'\"}', "\n")
      stop()
    }
 

--- a/R/faasr_get_file.R
+++ b/R/faasr_get_file.R
@@ -15,8 +15,9 @@ faasr_get_file <- function(faasr, server_name, remote_folder, remote_file, local
   if (server_name %in% names(faasr$DataStores)) {
     NULL
    } else {
-     cat('{\"faasr_get_file\":\"Invalid data server name: ',server_name,'\"}', "\n")
-     stop()
+     err_msg <- paste0('{\"faasr_get_file\":\"Invalid data server name: ',server_name,'\"}', "\n")
+     cat(err_msg)
+     stop()	
    }
 
   target_s3 <- faasr$DataStores[[server_name]]

--- a/R/faasr_init_log_folder.R
+++ b/R/faasr_init_log_folder.R
@@ -39,10 +39,11 @@ faasr_init_log_folder <- function(faasr) {
 
   check_UUIDfolder<-s3$list_objects_v2(Prefix=idfolder, Bucket=target_s3$Bucket)
   if (length(check_UUIDfolder$Contents)!=0){
-    cat('{\"msg\":\"faasr_init_log_folder: InvocationID already exists: ', faasr$InvocationID,'\"}', "\n")
-	stop()
-  } else {
-	s3$put_object(Key=idfolder, Bucket=target_s3$Bucket)
+    err_msg <- paste0('{\"faasr_init_log_folder\":\"InvocationID already exists: ', faasr$InvocationID,'\"}', "\n")
+    cat(err_msg)
+    stop()
+  }else{
+    s3$put_object(Key=idfolder, Bucket=target_s3$Bucket)
   }
   return(faasr)
 }

--- a/R/faasr_lock.R
+++ b/R/faasr_lock.R
@@ -8,7 +8,7 @@ library("paws")
 # Read-Set Memory implementation
 faasr_rsm <- function(faasr) {
   # Set env for flag and lock
-  flag_content <- as.character(sample(1:1000,1))
+  flag_content <- as.character(sample(1:10000000,1))
   flag_path <- paste0(faasr$FaaSrLog,"/", faasr$InvocationID,"/",faasr$FunctionInvoke,"/flag/")
   flag_name <- paste0(flag_path,flag_content)
   lock_name <- paste0(faasr$FaaSrLog,"/", faasr$InvocationID,"/",faasr$FunctionInvoke,"./lock")

--- a/R/faasr_log.R
+++ b/R/faasr_log.R
@@ -16,7 +16,8 @@ faasr_log <- function(faasr,log_message) {
   if (log_server_name %in% names(faasr$DataStores)) {
     NULL
    } else {
-     cat('{\"msg\":\"faasr_log: Invalid logging server name: ',log_server_name,'\"}', "\n")
+     err_msg <- paste0('{\"faasr_log\":\"Invalid logging server name: ',log_server_name,'\"}', "\n")
+     cat(err_msg)
      stop()
    }
 

--- a/R/faasr_parse.R
+++ b/R/faasr_parse.R
@@ -21,7 +21,8 @@ faasr_parse <- function(faasr_payload) {
     NULL
   } else {
 	log <- attr(validate(faasr_payload),"err")
-	cat('{\"faasr_parse: Invalid JSON Payload\":\"',log,'\"}', "\n")
+	err_msg <- paste0('{\"faasr_parse\":\"Invalid JSON Payload: ',log,'\"}', "\n")
+	cat(err_msg)
 	stop()
   }
 
@@ -30,7 +31,8 @@ faasr_parse <- function(faasr_payload) {
   if (faasr_schema_valid(faasr_payload)) {
     return(faasr)
   } else {
-	cat('{\"msg\":\"faasr_parse: JSON Payload not compliant with FaaSr schema\"}', "\n")
+	err_msg <- paste0('{\"faasr_parse\":\"JSON Payload not compliant with FaaSr schema\"}', "\n")
+	cat()
     stop()
 
 	# Room for improvement: it can return 1. error msg, 2. logs from jsonvalidate.

--- a/R/faasr_put_file.R
+++ b/R/faasr_put_file.R
@@ -16,7 +16,8 @@ faasr_put_file <- function(faasr, server_name, local_folder, local_file, remote_
   if (server_name %in% names(faasr$DataStores)) {
     NULL
   } else {
-    cat('{\"msg\":\"faasr_put_file: Invalid data server name: ',server_name,'\"}', "\n")
+    err_msg <- paste0('{\"faasr_put_file\":\"Invalid data server name: ',server_name,'\"}', "\n")
+    cat(err_msg)
     stop()
   }
 

--- a/R/faasr_start.R
+++ b/R/faasr_start.R
@@ -74,10 +74,10 @@ faasr_start <- function(faasr_payload) {
   faasr_trigger(faasr)
 
   # Log to standard output
-  msg_1 <- paste0('{\"msg\":\"faasr_start: Finished execution of User Function ',faasr$FunctionInvoke,'\"}', "\n")
+  msg_1 <- paste0('{\"faasr_start\":\"Finished execution of User Function ',faasr$FunctionInvoke,'\"}', "\n")
   cat(msg_1)
   result <- faasr_log(faasr, msg_1)
-  msg_2 <- paste0('{\"msg\":\"faasr_start: With Action Invocation ID is ',faasr$InvocationID,'\"}', "\n")
+  msg_2 <- paste0('{\"faasr_start\":\"With Action Invocation ID is ',faasr$InvocationID,'\"}', "\n")
   cat(msg_2)
   result <- faasr_log(faasr, msg_2)
 }

--- a/R/faasr_trigger.R
+++ b/R/faasr_trigger.R
@@ -22,7 +22,7 @@ faasr_trigger <- function(faasr) {
 
   # Check if the list is empty or not
   if (length(invoke_next) == 0) {
-  	err_msg <- paste0('{\"msg\":\"faasr_trigger: no triggers for ',user_function,'\"}', "\n")
+    err_msg <- paste0('{\"faasr_trigger\":\"no triggers for ',user_function,'\"}', "\n")
     cat(err_msg)
     faasr_log(faasr, err_msg)
   } else {
@@ -40,7 +40,7 @@ faasr_trigger <- function(faasr) {
       if (next_server %in% names(faasr$ComputeServers)) {
         NULL
       } else {
-      	err_msg <- paste0('{\"msg\":\"faasr_trigger: invalid server name: ',next_server,'\"}', "\n")
+      	err_msg <- paste0('{\"faasr_trigger\":\"invalid server name: ',next_server,'\"}', "\n")
         cat(err_msg)
         faasr_log(faasr, err_msg)
         break
@@ -82,9 +82,10 @@ faasr_trigger <- function(faasr) {
 	      token <- paste("Bearer",result$access_token)
 	    # if result returns an error, return an error message and stop.
 	    } else {
+	      err_msg <- paste0('{\"faasr_trigger\":\"unable to invoke next action, authentication error\"}', "\n")
+	      cat(err_msg)
 	      faasr_log(faasr, result$errorMessage)
-		  cat('{\"msg\":\"faasr_trigger: unable to invoke next action, authentication error\"}', "\n")
-		  break
+	      break
 		}
 
 	    # Openwhisk - Invoke next action - action name should be described.
@@ -108,7 +109,7 @@ faasr_trigger <- function(faasr) {
         # if next action's server is not Openwhisk, it returns a message about the next function.
         # TBD need to verify this else statement - unclear
       } else {
-      	  succ_msg <- paste0('{\"msg\":\"faasr_trigger: success_',user_function,'_next_action_',invoke_next_function,'will_be_executed by_',next_server_type,'\"}', "\n")
+      	  succ_msg <- paste0('{\"faasr_trigger\":\"success_',user_function,'_next_action_',invoke_next_function,'_will_be_executed by_',next_server_type,'\"}', "\n")
           cat(succ_msg)
           faasr_log(faasr, succ_msg)
       }
@@ -142,12 +143,13 @@ faasr_trigger <- function(faasr) {
           cat(succ_msg)
           faasr_log(faasr, succ_msg)
         } else {
-          faasr_log(faasr, response$StatusCode)
-          cat("faasr_trigger: Error invoking: ",faasr$FunctionInvoke," reason:", response$StatusCode, "\n")
+	  err_msg <- paste0("faasr_trigger: Error invoking: ",faasr$FunctionInvoke," reason:", response$StatusCode, "\n")
+          cat(err_msg)
+	  faasr_log(faasr, response$StatusCode)
         }
       # TBD need to verify this else statement - unclear
       } else {
-      	succ_msg <- paste0('{\"msg\":\"faasr_trigger: success_',user_function,'_next_action_',invoke_next_function,'will_be_executed by_',next_server_type,'\"}', "\n")
+      	succ_msg <- paste0('{\"faasr_trigger\":\"success_',user_function,'_next_action_',invoke_next_function,'_will_be_executed by_',next_server_type,'\"}', "\n")
         cat(succ_msg)
         faasr_log(faasr, succ_msg)
       }
@@ -202,16 +204,16 @@ faasr_trigger <- function(faasr) {
           cat(succ_msg)
           faasr_log(faasr,succ_msg)
         } else {
-          cat("faasr_trigger: GitHub Action: error happens when invoke next function\n")
-          faasr_log(faasr, "faasr_trigger: GitHub Action: error happens when invoke next function\n")
+	  err_msg <- paste0("faasr_trigger: GitHub Action: error happens when invoke next function\n")
+          cat(err_msg)
+          faasr_log(faasr, err_msg)
         }
       # TBD need to verify this else statement - unclear
       } else {
-      	succ_msg <- paste0('{\"msg\":\"faasr_trigger: success_',user_function,'_next_action_',invoke_next_function,'will_be_executed by_',next_server_type,'\"}', "\n")
+      	succ_msg <- paste0('{\"faasr_trigger\":\"success_',user_function,'_next_action_',invoke_next_function,'will_be_executed by_',next_server_type,'\"}', "\n")
         cat(succ_msg)
         faasr_log(faasr, succ_msg)
       }
-
     }
   }
 }


### PR DESCRIPTION
[Standardize msg/cat/log] "msg" using paste0 / "cat(msg)" / "faasr_log(msg, faasr)"
 ** if the msg is related to the logging server error, it does not leave "faasr_log".
 ** if the msg is too long, detail will be delivered to the log server by "faasr_log", not leaving the cat message.
[Get rid of "msg"] While standardizing, messages starting with "msg:" are replaced by the messages starting with "function's name" such as "faasr_start"
[Raise the random number scale] For "faasr_lock" and "faasr_abort_on_multiple_invocations", the scale of random number is raised from "1,000 and 10,000" to "10,000,000" to avoid collision