### PR TITLE
[JSON Validator Logs] JSON Validator logs should be maintained.

### DIFF
--- a/R/faasr_parse.R
+++ b/R/faasr_parse.R
@@ -31,16 +31,18 @@ faasr_parse <- function(faasr_payload) {
   if (faasr_schema_valid(faasr_payload)) {
     return(faasr)
   } else {
-	err_msg <- paste0('{\"faasr_parse\":\"JSON Payload not compliant with FaaSr schema\"}', "\n")
+	#err_msg <- paste0('{\"faasr_parse\":\"JSON Payload not compliant with FaaSr schema\"}', "\n")
+	#cat(err_msg)
+	  
+	message_schema <- attr(faasr_schema_valid(faasr_payload, verbose=TRUE, greedy=TRUE),"errors")
+        tag <- c("schemaPath", "message")
+        log <- message_schema[,tag]
+        log_s <- paste(log$schemaPath, log$message, "\n", sep = " ")
+        cat(log_s)
+	err_msg <- paste0('{\"faasr_parse\":\"JSON Payload error-check openwhisk activation logs for more information\"}', "\n")
 	cat(err_msg)
-    stop()
+        stop()
 
-	# Room for improvement: it can return 1. error msg, 2. logs from jsonvalidate.
-	# message_schema <- attr(faasr_schema_valid(faasr_payload, verbose=TRUE, greedy=TRUE),"errors")
-	# tag <- c("schemaPath", "message")
-	# log <- message_schema[,tag]
-	# log_json <- toJSON(log)
-	# cat('{\"msg\":\"',log_json,'\"}', "\n")
   }
 }
 

--- a/R/faasr_parse.R
+++ b/R/faasr_parse.R
@@ -39,10 +39,9 @@ faasr_parse <- function(faasr_payload) {
         log <- message_schema[,tag]
         log_s <- paste(log$schemaPath, log$message, "\n", sep = " ")
         cat(log_s)
-	err_msg <- paste0('{\"faasr_parse\":\"JSON Payload error-check openwhisk activation logs for more information\"}', "\n")
+	err_msg <- paste0('{\"faasr_parse\":\"JSON Payload error - please check the logs for your FaaS provider for more information\"}', "\n")
 	cat(err_msg)
         stop()
-
   }
 }
 


### PR DESCRIPTION
[faasr_parse.R] now it returns JSON validator's error logs. User should take a look by using activation logs, e.g., ibmcloud fn activation logs -logs-