### PR TITLE
[faasr naming] Hiding the variable "faasr" from the user sides.

### DIFF
--- a/R/faasr_abort_on_multiple_invocations.R
+++ b/R/faasr_abort_on_multiple_invocations.R
@@ -41,7 +41,7 @@ faasr_abort_on_multiple_invocations <- function(faasr, pre) {
     if (length(check_fn_done$Contents) == 0){
       res_msg <- paste0('{\"faasr_abort_on_multiple_invocations\":\"not the last trigger invoked - no flag\"}', "\n")
       cat(res_msg)
-      faasr_log(faasr, res_msg)
+      faasr_log(res_msg)
       stop()
     }
   }
@@ -98,7 +98,7 @@ faasr_abort_on_multiple_invocations <- function(faasr, pre) {
   } else {
     res_msg <- paste0('{\"faasr_abort_on_multiple_invocations\":\"not the last trigger invoked - random number does not match\"}', "\n")
     cat(res_msg)
-    faasr_log(faasr, res_msg)
+    faasr_log(res_msg)
     stop()
   }
 }

--- a/R/faasr_check_workflow_cycle.R
+++ b/R/faasr_check_workflow_cycle.R
@@ -19,7 +19,7 @@ faasr_check_workflow_cycle <- function(faasr){
     if (!(func %in% names(faasr$FunctionList))){
       err_msg <- paste0('{\"faasr_check_workflow_cycle\":\"unreachable state or invalid function name is found in ',func,'\"}', "\n")
       cat(err_msg)
-      faasr_log(faasr, err_msg)
+      faasr_log(err_msg)
       stop()
     }
   }
@@ -34,7 +34,7 @@ faasr_check_workflow_cycle <- function(faasr){
     if (target %in% graph[[start]]) {
 	  err_msg <- paste0('{\"faasr_check_workflow_cycle\":\"function loop found in ',target,'\"}', "\n")
 	  cat(err_msg)
-	  faasr_log(faasr, err_msg)
+	  faasr_log(err_msg)
 	  stop()
 	}
 

--- a/R/faasr_get_file.R
+++ b/R/faasr_get_file.R
@@ -11,13 +11,11 @@ library("paws")
 
 # Default server_name is Logging Server, default remote folder name is empty ("") and 
 # local folder name is current directory(".")
-faasr_get_file <- function(server_name=.faasr$LoggingServer, remote_folder="", remote_file, local_folder=".", local_file) {
-  # Define "faasr" by using global variable ".faasr" 
-  faasr <- .faasr
+faasr_get_file <- function(server_name=.faasr$LoggingServer, remote_folder="", remote_file, local_folder=".", local_file) { 
   # Check that an S3 server_name has been defined
   # If not, log an error and abort
   
-  if (server_name %in% names(faasr$DataStores)) {
+  if (server_name %in% names(.faasr$DataStores)) {
     NULL
    } else {
      err_msg <- paste0('{\"faasr_get_file\":\"Invalid data server name: ',server_name,'\"}', "\n")
@@ -25,7 +23,7 @@ faasr_get_file <- function(server_name=.faasr$LoggingServer, remote_folder="", r
      stop()	
    }
 
-  target_s3 <- faasr$DataStores[[server_name]]
+  target_s3 <- .faasr$DataStores[[server_name]]
 
   # Remove "/" in the folder & file name to avoid situations:
   # 1: duplicated "/" ("/remote/folder/", "/file_name") 

--- a/R/faasr_get_file.R
+++ b/R/faasr_get_file.R
@@ -9,9 +9,14 @@
 
 library("paws")
 
-faasr_get_file <- function(faasr, server_name, remote_folder, remote_file, local_folder, local_file) {
+# Default server_name is Logging Server, default remote folder name is empty ("") and 
+# local folder name is current directory(".")
+faasr_get_file <- function(server_name=.faasr$LoggingServer, remote_folder="", remote_file, local_folder=".", local_file) {
+  # Define "faasr" by using global variable ".faasr" 
+  faasr <- .faasr
   # Check that an S3 server_name has been defined
   # If not, log an error and abort
+  
   if (server_name %in% names(faasr$DataStores)) {
     NULL
    } else {
@@ -21,8 +26,26 @@ faasr_get_file <- function(faasr, server_name, remote_folder, remote_file, local
    }
 
   target_s3 <- faasr$DataStores[[server_name]]
-  get_file <- paste0(local_folder,"/",local_file)
+
+  # Remove "/" in the folder & file name to avoid situations:
+  # 1: duplicated "/" ("/remote/folder/", "/file_name") 
+  # 2: multiple "/" by user mistakes ("//remote/folder//", "file_name")
+  # 3: file_name ended with "/" ("/remote/folder", "file_name/")
+  remote_folder <- sub("^/+", "", sub("/+$", "", remote_folder))
+  remote_file <- sub("^/+", "", sub("/+$", "", remote_file))
   get_file_s3 <- paste0(remote_folder, "/", remote_file)
+
+  # Check the situation that local_path is not defined and local_folder is defined as an absoulte path.
+  if (local_folder="." && local_file == normalizePath(local_file)){
+    local_folder <- dirname(local_file)
+    get_file <- local_file
+  # If not, takes same way with remote folder & file
+  } else{
+    local_folder <- sub("^/+", "", sub("/+$", "", local_folder))
+    local_file <- sub("^/+", "", sub("/+$", "", local_file))
+    get_file <- paste0(local_folder,"/",local_file)
+  }  
+  
   if (!dir.exists(local_folder)) {
     dir.create(local_folder, recursive=TRUE)
   }

--- a/R/faasr_log.R
+++ b/R/faasr_log.R
@@ -7,13 +7,13 @@
 
 library("paws")
 
-faasr_log <- function(faasr,log_message) {
+faasr_log <- function(log_message) {
 
   # Extract name of logging server
-  log_server_name = faasr$LoggingServer
+  log_server_name = .faasr$LoggingServer
 
   # Validate that server_name exists, otherwise abort
-  if (log_server_name %in% names(faasr$DataStores)) {
+  if (log_server_name %in% names(.faasr$DataStores)) {
     NULL
    } else {
      err_msg <- paste0('{\"faasr_log\":\"Invalid logging server name: ',log_server_name,'\"}', "\n")
@@ -21,7 +21,7 @@ faasr_log <- function(faasr,log_message) {
      stop()
    }
 
-  log_server <- faasr$DataStores[[log_server_name]]
+  log_server <- .faasr$DataStores[[log_server_name]]
 
   s3<-paws::s3(
     config=list(
@@ -37,8 +37,8 @@ faasr_log <- function(faasr,log_message) {
   )
 
   # set file name to be "faasr_log_" + faasr$InvocationID + faasr$FunctionInvoke + ".txt"
-  log_folder <- paste0(faasr$FaaSrLog, "/", faasr$InvocationID)
-  log_file <- paste0(log_folder, "/", faasr$FunctionInvoke,".txt")
+  log_folder <- paste0(.faasr$FaaSrLog, "/", .faasr$InvocationID)
+  log_file <- paste0(log_folder, "/", .faasr$FunctionInvoke,".txt")
   if (!dir.exists(log_folder)){dir.create(log_folder, recursive=TRUE)}
 
   check_log_file <- s3$list_objects_v2(Bucket=log_server$Bucket, Prefix=log_file)

--- a/R/faasr_put_file.R
+++ b/R/faasr_put_file.R
@@ -9,11 +9,13 @@
 
 library("paws")
 
-faasr_put_file <- function(faasr, server_name, local_folder, local_file, remote_folder, remote_file) {
+# Default server_name is Logging Server, default remote folder name is empty ("") and 
+# local folder name is current directory(".")
+faasr_put_file <- function(server_name=.faasr$LoggingServer, local_folder=".", local_file, remote_folder="", remote_file) {
 
   # Check that an S3 server_name has been defined
   # If not, log an error and abort
-  if (server_name %in% names(faasr$DataStores)) {
+  if (server_name %in% names(.faasr$DataStores)) {
     NULL
   } else {
     err_msg <- paste0('{\"faasr_put_file\":\"Invalid data server name: ',server_name,'\"}', "\n")
@@ -21,10 +23,27 @@ faasr_put_file <- function(faasr, server_name, local_folder, local_file, remote_
     stop()
   }
 
-  target_s3 <- faasr$DataStores[[server_name]]
-  put_file <- paste0(local_folder,"/",local_file)
+  target_s3 <- .faasr$DataStores[[server_name]]
+
+  # Remove "/" in the folder & file name to avoid situations:
+  # 1: duplicated "/" ("/remote/folder/", "/file_name") 
+  # 2: multiple "/" by user mistakes ("//remote/folder//", "file_name")
+  # 3: file_name ended with "/" ("/remote/folder", "file_name/")
+  remote_folder <- sub("^/+", "", sub("/+$", "", remote_folder))
+  remote_file <- sub("^/+", "", sub("/+$", "", remote_file))
   put_file_s3 <- paste0(remote_folder, "/", remote_file)
 
+  # Check the situation that local_path is not defined and local_folder is defined as an absoulte path.
+  if (local_folder="." && local_file == normalizePath(local_file)){
+    local_folder <- dirname(local_file)
+    put_file <- local_file
+  # If not, takes same way with remote folder & file
+  } else{
+    local_folder <- sub("^/+", "", sub("/+$", "", local_folder))
+    local_file <- sub("^/+", "", sub("/+$", "", local_file))
+    put_file <- paste0(local_folder,"/",local_file)
+  }  
+ 
   s3 <- paws::s3(
 	  config=list(
 		  credentials=list(

--- a/R/faasr_s3_check.R
+++ b/R/faasr_s3_check.R
@@ -20,7 +20,7 @@ faasr_s3_check <- function(faasr){
       }
     }
     if (length(region_check)==0 || region_check==""){
-      faasr$DataStores[[server]]$Region <- "region"
+      faasr$DataStores[[server]]$Region <- "us-east-1"
     }
     s3<-paws::s3(
       config=list(

--- a/R/faasr_start.R
+++ b/R/faasr_start.R
@@ -66,7 +66,7 @@ faasr_start <- function(faasr_payload) {
   user_function = tryCatch(expr=get(.faasr$FunctionInvoke), error=function(e){
     err_msg <- paste0('{\"faasr_start\":\"Cannot find FunctionInvoke ',.faasr$FunctionInvoke,', check the name and sources\"}', "\n")
     cat(err_msg)
-    result <- faasr_log(.faasr, err_msg)
+    result <- faasr_log(err_msg)
     stop()
     }
   )
@@ -81,8 +81,8 @@ faasr_start <- function(faasr_payload) {
     err_msg <- paste0('{\"faasr_start\":\"Errors in the user function: ',.faasr$FunctionInvoke,', check the log for the detail \"}', "\n")
     cat(nat_err_msg)
     cat(err_msg)
-    result <- faasr_log(.faasr, err_msg)
-    result_2 <- faasr_log(.faasr, nat_err_msg)
+    result <- faasr_log(err_msg)
+    result_2 <- faasr_log(nat_err_msg)
     stop()
     }
   )
@@ -104,8 +104,8 @@ faasr_start <- function(faasr_payload) {
   # Log to standard output
   msg_1 <- paste0('{\"faasr_start\":\"Finished execution of User Function ',.faasr$FunctionInvoke,'\"}', "\n")
   cat(msg_1)
-  result <- faasr_log(.faasr, msg_1)
+  result <- faasr_log(msg_1)
   msg_2 <- paste0('{\"faasr_start\":\"With Action Invocation ID is ',.faasr$InvocationID,'\"}', "\n")
   cat(msg_2)
-  result <- faasr_log(.faasr, msg_2)
+  result <- faasr_log(msg_2)
 }

--- a/R/faasr_start.R
+++ b/R/faasr_start.R
@@ -29,21 +29,21 @@ faasr_start <- function(faasr_payload) {
   # First, call faasr_parse to validate the Payload received upon Action invocation
   # If parsing is successful, faasr is an R list storing the parsed JSON Payload
   # If parsing is not successful, the Action aborts with stop() before executing the User Function
-  faasr <<- faasr_parse(faasr_payload)
+  .faasr <<- faasr_parse(faasr_payload)
 
   # Build a data structure representing the User Workflow, from the parsed Payload
   # FaaSr only supports Directed Acyclic Graph (DAG) User Workflows, with a single entry point
   # If the User Workflow is not a DAG, the Action aborts with stop() before executing the User Function
-  graph <- faasr_check_workflow_cycle(faasr)
+  graph <- faasr_check_workflow_cycle(.faasr)
 
   # Check endpoint/region of the Logging server / TBD: Check all the DataStores servers
   # If endpoint is not defined(length==0) or empty(=="", for else cases), set empty value ""
   # If endpoint is not empty(not S3), check whether endpoint starts with http
   # If region is not defined(length==0) or empty(==""), set any value("region" in this case).
-  faasr <<- faasr_s3_check(faasr)
+  .faasr <<- faasr_s3_check(.faasr)
 
   # Make a list of all User Functions that are the predecessors of this User Function, if any
-  pre <- faasr_predecessors_list(faasr, graph)
+  pre <- faasr_predecessors_list(.faasr, graph)
 
   # If this User Function has zero predecessors, it is the single entry point
   # In this case, create the log folder in S3 logs buket
@@ -51,38 +51,38 @@ faasr_start <- function(faasr_payload) {
   # The log folder must be a unique name for each Action, such as a user-provided unique timestamp or UUID
   # If a log folder already exists, the Action aborts with stop() before executing the User Function
   if (length(pre) == 0) {
-    faasr <<- faasr_init_log_folder(faasr)
+    .faasr <<- faasr_init_log_folder(.faasr)
   }
 
   # If a User Function has more than one predecessors, this Action may or may not invoke the User Function
   # Only the last Action should invoke the User Function; all other Action invocations must abort
   if (length(pre) > 1) {
-    faasr_abort_on_multiple_invocations(faasr, pre)
+    faasr_abort_on_multiple_invocations(.faasr, pre)
   }
   
   # If the Action reaches this point without aborting, it is ready to invoke the User Function
   # Extract the name of the User Function from the Payload, and invoke it, passing the parsed Payload as arg
   # try get(faasr$FunctionInvoke) and if there's an error, return error message and stop the function
-  user_function = tryCatch(expr=get(faasr$FunctionInvoke), error=function(e){
-    err_msg <- paste0('{\"faasr_start\":\"Cannot find FunctionInvoke ',faasr$FunctionInvoke,', check the name and sources\"}', "\n")
+  user_function = tryCatch(expr=get(.faasr$FunctionInvoke), error=function(e){
+    err_msg <- paste0('{\"faasr_start\":\"Cannot find FunctionInvoke ',.faasr$FunctionInvoke,', check the name and sources\"}', "\n")
     cat(err_msg)
-    result <- faasr_log(faasr, err_msg)
+    result <- faasr_log(.faasr, err_msg)
     stop()
     }
   )
   
   # Get a list of the current function's arguments.
-  user_args = faasr_get_user_function_args(faasr)
+  user_args = faasr_get_user_function_args(.faasr)
   
   # Use do.call to use user_function with arguments
   # try do.call and if there's an error, return error message and stop the function
   faasr_result <- tryCatch(expr=do.call(user_function, user_args), error=function(e){
     nat_err_msg <- paste0('\"faasr_start\": ', as.character(e))
-    err_msg <- paste0('{\"faasr_start\":\"Errors in the user function: ',faasr$FunctionInvoke,', check the log for the detail \"}', "\n")
+    err_msg <- paste0('{\"faasr_start\":\"Errors in the user function: ',.faasr$FunctionInvoke,', check the log for the detail \"}', "\n")
     cat(nat_err_msg)
     cat(err_msg)
-    result <- faasr_log(faasr, err_msg)
-    result_2 <- faasr_log(faasr, nat_err_msg)
+    result <- faasr_log(.faasr, err_msg)
+    result_2 <- faasr_log(.faasr, nat_err_msg)
     stop()
     }
   )
@@ -90,22 +90,22 @@ faasr_start <- function(faasr_payload) {
   # At this point, the Action has finished the invocation of the User Function
   # We flag this by uploading a file with name FunctionInvoke.done with contents TRUE to the S3 logs folder
   # Check if directory already exists. If not, create one
-  log_folder <- paste0(faasr$FaaSrLog,"/",faasr$InvocationID)
+  log_folder <- paste0(.faasr$FaaSrLog,"/",.faasr$InvocationID)
   if (!dir.exists(log_folder)) {
     dir.create(log_folder, recursive=TRUE)
   }
-  file_name <- paste0(faasr$FunctionInvoke, ".done")
+  file_name <- paste0(.faasr$FunctionInvoke, ".done")
   write.table("TRUE", file=paste0(log_folder, "/", file_name), row.names=F, col.names=F)
-  faasr_put_file(faasr, faasr$LoggingServer, log_folder, file_name, log_folder, file_name)
+  faasr_put_file(.faasr$LoggingServer, log_folder, file_name, log_folder, file_name)
 
   # Now trigger the next Actions(s), if there are any in the User Workflow
-  faasr_trigger(faasr)
+  faasr_trigger(.faasr)
 
   # Log to standard output
-  msg_1 <- paste0('{\"faasr_start\":\"Finished execution of User Function ',faasr$FunctionInvoke,'\"}', "\n")
+  msg_1 <- paste0('{\"faasr_start\":\"Finished execution of User Function ',.faasr$FunctionInvoke,'\"}', "\n")
   cat(msg_1)
-  result <- faasr_log(faasr, msg_1)
-  msg_2 <- paste0('{\"faasr_start\":\"With Action Invocation ID is ',faasr$InvocationID,'\"}', "\n")
+  result <- faasr_log(.faasr, msg_1)
+  msg_2 <- paste0('{\"faasr_start\":\"With Action Invocation ID is ',.faasr$InvocationID,'\"}', "\n")
   cat(msg_2)
-  result <- faasr_log(faasr, msg_2)
+  result <- faasr_log(.faasr, msg_2)
 }

--- a/R/faasr_trigger.R
+++ b/R/faasr_trigger.R
@@ -24,7 +24,7 @@ faasr_trigger <- function(faasr) {
   if (length(invoke_next) == 0) {
     err_msg <- paste0('{\"faasr_trigger\":\"no triggers for ',user_function,'\"}', "\n")
     cat(err_msg)
-    faasr_log(faasr, err_msg)
+    faasr_log(err_msg)
   } else {
     # Iterate through invoke_next and use FaaS-specific mechanisms to send trigger
     # use "for" loop to iteratively check functions in invoke_next list
@@ -42,7 +42,7 @@ faasr_trigger <- function(faasr) {
       } else {
       	err_msg <- paste0('{\"faasr_trigger\":\"invalid server name: ',next_server,'\"}', "\n")
         cat(err_msg)
-        faasr_log(faasr, err_msg)
+        faasr_log(err_msg)
         break
       }
 
@@ -84,7 +84,7 @@ faasr_trigger <- function(faasr) {
 	    } else {
 	      err_msg <- paste0('{\"faasr_trigger\":\"unable to invoke next action, authentication error\"}', "\n")
 	      cat(err_msg)
-	      faasr_log(faasr, err_msg)
+	      faasr_log(err_msg)
 	      break
 		}
 
@@ -111,7 +111,7 @@ faasr_trigger <- function(faasr) {
       } else {
       	  succ_msg <- paste0('{\"faasr_trigger\":\"success_',user_function,'_next_action_',invoke_next_function,'_will_be_executed by_',next_server_type,'\"}', "\n")
           cat(succ_msg)
-          faasr_log(faasr, succ_msg)
+          faasr_log(succ_msg)
       }
 
        # if AWS Lambda - use Lambda API
@@ -141,17 +141,17 @@ faasr_trigger <- function(faasr) {
         if (response$StatusCode == 200) {
           succ_msg <- paste0("faasr_trigger: Successfully invoked:", faasr$FunctionInvoke, "\n")
           cat(succ_msg)
-          faasr_log(faasr, succ_msg)
+          faasr_log(succ_msg)
         } else {
 	  err_msg <- paste0("faasr_trigger: Error invoking: ",faasr$FunctionInvoke," reason:", response$StatusCode, "\n")
           cat(err_msg)
-	  faasr_log(faasr, err_msg)
+	  faasr_log(err_msg)
         }
       # TBD need to verify this else statement - unclear
       } else {
       	succ_msg <- paste0('{\"faasr_trigger\":\"success_',user_function,'_next_action_',invoke_next_function,'_will_be_executed by_',next_server_type,'\"}', "\n")
         cat(succ_msg)
-        faasr_log(faasr, succ_msg)
+        faasr_log(succ_msg)
       }
 
       # if GitHub Actions - use GH Actions
@@ -205,29 +205,29 @@ faasr_trigger <- function(faasr) {
         if (status_code(response) == 204) {
           succ_msg <- paste0("faasr_trigger: GitHub Action: Successfully invoked:", faasr$FunctionInvoke, "\n")
           cat(succ_msg)
-          faasr_log(faasr,succ_msg)
+          faasr_log(succ_msg)
         } else if (status_code(response) == 401) {
 	  err_msg <- paste0("faasr_trigger: GitHub Action: Authentication failed, check the credentials\n")
           cat(err_msg)
-          faasr_log(faasr,err_msg)
+          faasr_log(err_msg)
 	} else if (status_code(response) == 404) {
 	  err_msg <- paste0("faasr_trigger: GitHub Action: Cannot find the destination, check the actionname: \"",repo,"\" and workflow name: \"",workflow_file,"\"\n")
           cat(err_msg)
-          faasr_log(faasr,err_msg)
+          faasr_log(err_msg)
 	} else if (status_code(response) == 422) {
 	  err_msg <- paste0("faasr_trigger: GitHub Action: Cannot find the destination, check the ref: ", faasr$FunctionInvoke, "\n")
           cat(err_msg)
-          faasr_log(faasr,err_msg)
+          faasr_log(err_msg)
 	} else {
 	  err_msg <- paste0("faasr_trigger: GitHub Action: unknown error happens when invoke next function\n")
           cat(err_msg)
-          faasr_log(faasr, err_msg)
+          faasr_log(err_msg)
         }
       # TBD need to verify this else statement - unclear
       } else {
       	succ_msg <- paste0('{\"faasr_trigger\":\"success_',user_function,'_next_action_',invoke_next_function,'will_be_executed by_',next_server_type,'\"}', "\n")
         cat(succ_msg)
-        faasr_log(faasr, succ_msg)
+        faasr_log(succ_msg)
       }
     }
   }


### PR DESCRIPTION
[get_file/put_file/log] Remove "faasr" from the arguments and set default value for the arguments such as "remote_folder" or "server_name".
[All related R file] Change "faasr" to ".faasr" to avoid the case if users use "faasr" as their customized variable.
[get_file/put_file] Add some error correction code for the case users use wrong arguments. e.g., remote_folder = "/folder/", remote_file = "/file.txt", which becomes "/folder//file.txt"