### PR TITLE
[check_workflow_cycle] Function doesn't catch "unreachable state" and "Invalid function name"

### DIFF
--- a/R/faasr_check_workflow_cycle.R
+++ b/R/faasr_check_workflow_cycle.R
@@ -58,8 +58,8 @@ faasr_check_workflow_cycle <- function(faasr){
   # do dfs starting with function invoke.
   dfs(faasr$FunctionInvoke, faasr$FunctionInvoke)
 
-  for (func in names(faasr$FuntionList){
-    if (func %in% stack){
+  for (func in names(faasr$FuntionList)){
+    if (!(func %in% stack)){
       err_msg <- paste0('{\"faasr_check_workflow_cycle\":\"unreachable state is found in ',func,'\"}', "\n")
       cat(err_msg)
       faasr_log(err_msg)

--- a/R/faasr_check_workflow_cycle.R
+++ b/R/faasr_check_workflow_cycle.R
@@ -23,6 +23,7 @@ faasr_check_workflow_cycle <- function(faasr){
       faasr_log(err_msg)
       stop()
       }
+    }
   }
 
   # build an empty list of stacks - this will prevent the infinite loop

--- a/R/faasr_check_workflow_cycle.R
+++ b/R/faasr_check_workflow_cycle.R
@@ -59,7 +59,7 @@ faasr_check_workflow_cycle <- function(faasr){
   # do dfs starting with function invoke.
   dfs(faasr$FunctionInvoke, faasr$FunctionInvoke)
 
-  for (func in names(faasr$FuntionList)){
+  for (func in names(faasr$FunctionList)){
     if (!(func %in% stack)){
       err_msg <- paste0('{\"faasr_check_workflow_cycle\":\"unreachable state is found in ',func,'\"}', "\n")
       cat(err_msg)

--- a/R/faasr_check_workflow_cycle.R
+++ b/R/faasr_check_workflow_cycle.R
@@ -18,10 +18,10 @@ faasr_check_workflow_cycle <- function(faasr){
   for (func in names(graph)){
     for (path in graph[[func]]){
       if (!(path %in% names(faasr$FunctionList))){
-      err_msg <- paste0('{\"faasr_check_workflow_cycle\":\"invalid function name is found in ',func,'\"}', "\n")
-      cat(err_msg)
-      faasr_log(err_msg)
-      stop()
+        err_msg <- paste0('{\"faasr_check_workflow_cycle\":\"invalid next function ',path,' is found in ',func,'\"}', "\n")
+        cat(err_msg)
+        faasr_log(err_msg)
+        stop()
       }
     }
   }

--- a/R/faasr_check_workflow_cycle.R
+++ b/R/faasr_check_workflow_cycle.R
@@ -15,13 +15,14 @@ faasr_check_workflow_cycle <- function(faasr){
   }
 
   # check next functions of FunctionInvoke are in the function list
-  for (func in graph[[faasr$FunctionInvoke]]){	
-    if (!(func %in% names(faasr$FunctionList))){
-      err_msg <- paste0('{\"faasr_check_workflow_cycle\":\"unreachable state or invalid function name is found in ',func,'\"}', "\n")
+  for (func in names(graph)){
+    for (path in graph[[func]]){
+      if (!(path %in% names(faasr$FunctionList))){
+      err_msg <- paste0('{\"faasr_check_workflow_cycle\":\"invalid function name is found in ',func,'\"}', "\n")
       cat(err_msg)
       faasr_log(err_msg)
       stop()
-    }
+      }
   }
 
   # build an empty list of stacks - this will prevent the infinite loop
@@ -56,5 +57,15 @@ faasr_check_workflow_cycle <- function(faasr){
 
   # do dfs starting with function invoke.
   dfs(faasr$FunctionInvoke, faasr$FunctionInvoke)
+
+  for (func in names(faasr$FuntionList){
+    if (func %in% stack){
+      err_msg <- paste0('{\"faasr_check_workflow_cycle\":\"unreachable state is found in ',func,'\"}', "\n")
+      cat(err_msg)
+      faasr_log(err_msg)
+      stop()
+    }
+  }
+       
   return(graph)
 }


### PR DESCRIPTION
1. Compare graph values(the list of next invoke functions) with FunctionList: If there are functions that aren't included in the FunctionList, check-workflow_cycle() detects it "invalid function name".
2. Compare FunctionList with stack list. Functions in stack are all reachable state found by dfs: If there are functions that aren't included in the stack, check-workflow_cycle() detects it "unreachable state".