### PR TITLE
[LoggingServer -> LoggingDataStore / DefaultDataStore]

### DIFF
--- a/R/faasr_abort_on_multiple_invocations.R
+++ b/R/faasr_abort_on_multiple_invocations.R
@@ -17,6 +17,14 @@ faasr_abort_on_multiple_invocations <- function(faasr, pre) {
     log_server_name = faasr$LoggingDataStore
   }
   
+  if (log_server_name %in% names(.faasr$DataStores)) {
+    NULL
+  } else {
+    err_msg <- paste0('{\"faasr_abort_on_multiple_invocation\":\"Invalid data server name: ',log_server_name,'\"}', "\n")
+    cat(err_msg)
+    stop()	
+  }
+
   log_server <- faasr$DataStores[[log_server_name]]
   s3<-paws::s3(
     config=list(

--- a/R/faasr_abort_on_multiple_invocations.R
+++ b/R/faasr_abort_on_multiple_invocations.R
@@ -11,7 +11,12 @@ library("paws")
 faasr_abort_on_multiple_invocations <- function(faasr, pre) {
 
   # Set env for checking
-  log_server_name = faasr$LoggingServer
+  if (is.null(faasr$LoggingDataStore)){
+    log_server_name = faasr$DefaultDataStore
+  } else {
+    log_server_name = faasr$LoggingDataStore
+  }
+  
   log_server <- faasr$DataStores[[log_server_name]]
   s3<-paws::s3(
     config=list(

--- a/R/faasr_arrow_s3_bucket.R
+++ b/R/faasr_arrow_s3_bucket.R
@@ -1,0 +1,27 @@
+library("arrow")
+
+
+faasr_arrow_s3_bucket <- function(server_name=.faasr$DefaultDataStore) {
+  # Check that an S3 server_name has been defined
+  # If not, log an error and abort
+
+  if (server_name %in% names(.faasr$DataStores)) {
+    NULL
+  } else {
+    err_msg <- paste0('{\"faasr_get_arrow\":\"Invalid data server name: ',server_name,'\"}', "\n")
+    cat(err_msg)
+    stop()
+  }
+
+  target_s3 <- .faasr$DataStores[[server_name]]
+
+
+  s3 <- arrow::s3_bucket(
+    bucket = server_name,
+    access_key = target_s3$AccessKey,
+    secret_key = target_s3$SecretKey,
+    endpoint_override = target_s3$Endpoint
+  )
+
+  return(s3)
+}

--- a/R/faasr_arrow_s3_bucket.R
+++ b/R/faasr_arrow_s3_bucket.R
@@ -1,3 +1,9 @@
+#' @title Provide user functions for "arrow" library
+#' @description Uses "arrow" library to set up the configurations with given json file and 
+#'              provide the object to the users
+#' @param server_name for string, default value is faasr$DefaultDataStore
+#' @return s3 representing object for "arrow"
+
 library("arrow")
 
 

--- a/R/faasr_get_file.R
+++ b/R/faasr_get_file.R
@@ -9,9 +9,9 @@
 
 library("paws")
 
-# Default server_name is Logging Server, default remote folder name is empty ("") and 
+# Default server_name is DefaultDataStore, default remote folder name is empty ("") and 
 # local folder name is current directory(".")
-faasr_get_file <- function(server_name=.faasr$LoggingServer, remote_folder="", remote_file, local_folder=".", local_file) { 
+faasr_get_file <- function(server_name=.faasr$DefaultDataStore, remote_folder="", remote_file, local_folder=".", local_file) { 
   # Check that an S3 server_name has been defined
   # If not, log an error and abort
   

--- a/R/faasr_init_log_folder.R
+++ b/R/faasr_init_log_folder.R
@@ -16,7 +16,12 @@ faasr_init_log_folder <- function(faasr) {
     faasr$InvocationID<-UUIDgenerate()
   }
 
-  target_s3 <- faasr$LoggingServer
+  if (is.null(faasr$LoggingDataStore){
+    target_s3 <- faasr$DefaultDataStore
+  } else {
+    target_s3 <- faasr$LoggingDataStore
+  }
+      
   target_s3 <- faasr$DataStores[[target_s3]]
   s3<-paws::s3(
     config=list(

--- a/R/faasr_lock.R
+++ b/R/faasr_lock.R
@@ -14,7 +14,11 @@ faasr_rsm <- function(faasr) {
   lock_name <- paste0(faasr$FaaSrLog,"/", faasr$InvocationID,"/",faasr$FunctionInvoke,"./lock")
 
   # Set env for the storage.
-  target_s3 <- faasr$LoggingServer
+  if (is.null(faasr$LoggingDataStore)){
+    target_s3 <- faasr$DefaultDataStore
+  } else {
+    target_s3 <- faasr$LoggingDataStore
+  }
   target_s3 <- faasr$DataStores[[target_s3]]
   s3<-paws::s3(
     config=list(
@@ -76,7 +80,12 @@ faasr_acquire<-function(faasr) {
 faasr_release<-function(faasr) {
 	# Set env for locks.
 	lock_name <- paste0(faasr$FaaSrLog,"/", faasr$InvocationID,"/",faasr$FunctionInvoke,"./lock")
-	target_s3 <- faasr$LoggingServer
+	if (is.null(faasr$LoggingDataStore)){
+          target_s3 <- faasr$DefaultDataStore
+        } else {
+          target_s3 <- faasr$LoggingDataStore
+        }
+
 	target_s3 <- faasr$DataStores[[target_s3]]
 	s3<-paws::s3(
 	  config=list(

--- a/R/faasr_log.R
+++ b/R/faasr_log.R
@@ -10,8 +10,11 @@ library("paws")
 faasr_log <- function(log_message) {
 
   # Extract name of logging server
-  log_server_name = .faasr$LoggingServer
-
+  if (is.null(.faasr$LoggingDataStore){
+    log_server_name = .faasr$DefaultDataStore
+  } else {
+    log_server_name = .faasr$LoggingDataStore
+  }
   # Validate that server_name exists, otherwise abort
   if (log_server_name %in% names(.faasr$DataStores)) {
     NULL

--- a/R/faasr_put_file.R
+++ b/R/faasr_put_file.R
@@ -11,7 +11,7 @@ library("paws")
 
 # Default server_name is Logging Server, default remote folder name is empty ("") and 
 # local folder name is current directory(".")
-faasr_put_file <- function(server_name=.faasr$LoggingServer, local_folder=".", local_file, remote_folder="", remote_file) {
+faasr_put_file <- function(server_name=.faasr$DefaultDataStore, local_folder=".", local_file, remote_folder="", remote_file) {
 
   # Check that an S3 server_name has been defined
   # If not, log an error and abort

--- a/R/faasr_s3_check.R
+++ b/R/faasr_s3_check.R
@@ -14,7 +14,7 @@ faasr_s3_check <- function(faasr){
       faasr$DataStores[[server]]$Endpoint <- ""
     }else{
       if (!(startsWith(endpoint_check, "http"))){
-        msg <- paste0('{\"faasr_s3_check\":\"Invalid Logging server endpoint ',server,'\"}', "\n")
+        msg <- paste0('{\"faasr_s3_check\":\"Invalid Data store server endpoint ',server,'\"}', "\n")
         cat(msg)
         stop()
       }

--- a/R/faasr_start.R
+++ b/R/faasr_start.R
@@ -95,7 +95,7 @@ faasr_start <- function(faasr_payload) {
   }
   file_name <- paste0(.faasr$FunctionInvoke, ".done")
   write.table("TRUE", file=paste0(log_folder, "/", file_name), row.names=F, col.names=F)
-  faasr_put_file(.faasr$LoggingServer, log_folder, file_name, log_folder, file_name)
+  faasr_put_file(local_folder=log_folder, local_file=file_name, remote_folder=log_folder, remote_file=file_name)
 
   # Now trigger the next Actions(s), if there are any in the User Workflow
   faasr_trigger(.faasr)

--- a/schema/FaaSr.schema.json
+++ b/schema/FaaSr.schema.json
@@ -15,8 +15,13 @@
       "description": "The unique ID used throughout all action invocations for this workflow",
       "type": "string"
     },
-    "LoggingServer": {
+    "LoggingDataStore": {
       "description": "The name of the logging server to use - must match an S3 server defined under DataStores",
+      "type": "string",
+      "minLength": 1
+    },
+    "DefaultDataStore": {
+      "description": "The name of the default server to use - must match an S3 server defined under DataStores",
       "type": "string",
       "minLength": 1
     },
@@ -156,6 +161,6 @@
         }
     }
   },
-  "required": [ "FunctionInvoke", "LoggingServer", "FunctionList", "ComputeServers", "DataStores"]
+  "required": [ "FunctionInvoke", "DefaultDataStore", "FunctionList", "ComputeServers", "DataStores"]
 }
 


### PR DESCRIPTION
1. [FaaSr.schema.json] 
- LoggingServer -> LoggingDataStore, LoggingDataStore is not required anymore.
- DefaultDataStore is now added.
2. [faasr_get_file/faasr_put_file/faasr_log/faasr_abort_on_multiple_invocations/faasr_init_log_folder/faasr_lock/faasr_start]
- LoggingServer -> LoggingDataStore
- functions for users such as "faasr_get_file" are now using "DefaultDataStore" for its default data store server.
- functions using LoggingServer are now using "LoggingDataStore" and if its value is empty, they will use "DefaultDataStore"
3. [faasr_arrow_s3_bucket]
- file added
- It's using "DefaultDataStore" for the default data store server