### PR TITLE
[github package installation error]

### DIFF
--- a/R/faasr_client_api_github-actions.R
+++ b/R/faasr_client_api_github-actions.R
@@ -222,6 +222,7 @@ faasr_register_workflow_github_gh_setup <- function(check, repo, ref) {
     system("git init")
     msg <- paste0("git branch -m ", ref)
     system(msg)
+    system("git rm -r git rm -r --cached .")
     system("git add .")
     system("git commit -m \'build repo\'")
     cat("\n\n[faasr_msg] Create the repository\n")
@@ -254,6 +255,7 @@ faasr_register_workflow_github_gh_setup <- function(check, repo, ref) {
     system("git init")
     msg <- paste0("git checkout -B ", ref)
     system(msg)
+    system("git rm -r git rm -r --cached .")
     system("git add .")
     system("git commit -m \'update repo\'")
     # push it to the remote git repository
@@ -371,6 +373,7 @@ jobs:
   system("git init")
   msg <- paste0("git checkout -B ", ref)
   system(msg)
+  system("git rm -r git rm -r --cached .")
   system("git add .")
   system("git commit -m \'update repo\'")
   command <- paste0("git push -f http://github.com/", repo, " ", ref)

--- a/R/faasr_client_api_github-actions.R
+++ b/R/faasr_client_api_github-actions.R
@@ -133,7 +133,7 @@ faasr_register_workflow_github_create_env <- function(server_name, repo_name, cr
   # create a file ".env"
   writeLines(contents, ".env")
   # create a file ".gitignore"
-  writeLines(".env*",".gitignore")
+  writeLines(".env\n*~\n*.swp\n*.swo",".gitignore")
   # create a directory ".github/workflows"
   if (!dir.exists(".github/workflows")) {
     dir.create(".github/workflows", recursive=TRUE)

--- a/R/faasr_client_api_github-actions.R
+++ b/R/faasr_client_api_github-actions.R
@@ -133,7 +133,7 @@ faasr_register_workflow_github_create_env <- function(server_name, repo_name, cr
   # create a file ".env"
   writeLines(contents, ".env")
   # create a file ".gitignore"
-  writeLines(".env",".gitignore")
+  writeLines(".env*",".gitignore")
   # create a directory ".github/workflows"
   if (!dir.exists(".github/workflows")) {
     dir.create(".github/workflows", recursive=TRUE)
@@ -174,6 +174,7 @@ jobs:
     container: ",containername,"
     env:
       SECRET_PAYLOAD: ${{ secrets.SECRET_PAYLOAD }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       PAYLOAD_REPO: ${{ vars.PAYLOAD_REPO }}
       INPUT_ID: ${{ github.event.inputs.ID }}
       INPUT_INVOKENAME: ${{ github.event.inputs.InvokeName }}
@@ -342,6 +343,7 @@ jobs:
     container: ",faasr$ActionContainers[[target]],"
     env:
       SECRET_PAYLOAD: ${{ secrets.SECRET_PAYLOAD }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       PAYLOAD_REPO: ${{ vars.PAYLOAD_REPO }}
       INPUT_ID: ${{ github.event.inputs.ID || \'",id,"\'  }}
       INPUT_INVOKENAME: ${{ github.event.inputs.InvokeName || \'",target,"\' }}

--- a/R/faasr_client_tools.R
+++ b/R/faasr_client_tools.R
@@ -286,8 +286,8 @@ faasr <- function(json_path, env_path=NULL){
 # replace fake values into real values
 faasr_replace_values <- function(faasr, cred){
   for (name in names(faasr)) {
-    # skip the FunctionList
-    if (name == "FunctionList") {
+    # skip the FunctionList/FunctionGitRepo/FunctionCRANPackage/FunctionGitHubPackage
+    if (name == "FunctionList" || name=="FunctionGitRepo" || name == "FunctionCRANPackage" || name == "FunctionGitHubPackage") {
       next
     }
     # If the value is a list, call this function recursively


### PR DESCRIPTION
1. Github actions doesn't allow to install github pacakges unless token is provided.
- Add "GITHUB_TOKEN" secrets in the yaml file
- make git ignore "~", ".swp", and ".swo" - are tmp files.
- when create/update the git repo, remove the caches (git rm -r git rm -r --cached .)