### PR TITLE
[Divide "faasr_start" / Edit for CRAN submission / Bug fix / Typo fix]

### DIFF
--- a/R/faasr_abort_on_multiple_invocations.R
+++ b/R/faasr_abort_on_multiple_invocations.R
@@ -11,7 +11,6 @@
 #' @import paws
 #' @export
 
-globalVariables(".faasr")
 library("uuid")
 library("paws")
 
@@ -24,7 +23,7 @@ faasr_abort_on_multiple_invocations <- function(faasr, pre) {
     log_server_name = faasr$LoggingDataStore
   }
   
-  if (log_server_name %in% names(.faasr$DataStores)) {
+  if (log_server_name %in% names(faasr$DataStores)) {
     NULL
   } else {
     err_msg <- paste0('{\"faasr_abort_on_multiple_invocation\":\"Invalid data server name: ',log_server_name,'\"}', "\n")

--- a/R/faasr_abort_on_multiple_invocations.R
+++ b/R/faasr_abort_on_multiple_invocations.R
@@ -11,9 +11,6 @@
 #' @import paws
 #' @export
 
-library("uuid")
-library("paws")
-
 faasr_abort_on_multiple_invocations <- function(faasr, pre) {
 
   # Set env for checking

--- a/R/faasr_arrow_s3_bucket.R
+++ b/R/faasr_arrow_s3_bucket.R
@@ -9,8 +9,6 @@
 #' @export
 
 globalVariables(".faasr")
-library("arrow")
-
 
 faasr_arrow_s3_bucket <- function(server_name=.faasr$DefaultDataStore) {
   # Check that an S3 server_name has been defined

--- a/R/faasr_client_api_aws-lambda.R
+++ b/R/faasr_client_api_aws-lambda.R
@@ -456,7 +456,7 @@ check_lambda_exists <- function(function_name, cred, lambda_server_info) {
 #' @param current_lambda_instance a list form of current Lambda server information: id, keys, region
 #' @param max_retries a integer for the number of maximum tries
 #' @param sleep_seconds a integer for the time for sleep between retries
-#' @return a logicla value
+#' @return a logical value
 #' @import cli
 #' @import paws
 #' @export

--- a/R/faasr_client_api_aws-lambda.R
+++ b/R/faasr_client_api_aws-lambda.R
@@ -261,7 +261,7 @@ check_user_image_exist <- function(faasr, action_name, server_name, user_image_u
 
 #' @title faasr_register_workflow_aws_lambda_role_create
 #' @description 
-#' create the aws-lamda role named "faasr-lambda-role"
+#' create the aws-lambda role named "faasr-lambda-role"
 #' @param faasr a list form of the JSON file
 #' @param cred a list form of the credentials
 #' @param lambda_server_info a list form of Lambda server information: id, keys, region

--- a/R/faasr_client_api_aws-lambda.R
+++ b/R/faasr_client_api_aws-lambda.R
@@ -128,7 +128,7 @@ faasr_register_workflow_lambda_function_lists <- function(faasr,cred, lambda_ser
       cli_alert_info("Do you want to update?[y/n]")
       while(TRUE) {
         check <- readline()
-        if(check == "y"){
+        if(check == "y" || check == ""){
           lambda_function_info[[action_name]]$action <- "update"
           break
         } else if(check == 'n'){

--- a/R/faasr_client_api_github-actions.R
+++ b/R/faasr_client_api_github-actions.R
@@ -425,9 +425,16 @@ faasr_register_workflow_git_remote_repo <- function(token,check,private,repo,ref
       stop()
     }
   }
+  # set the config
+  system("git config --global user.name 'github-actions[bot]'", ignore.stderr=TRUE, ignore.stdout=TRUE)
+  system("git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'"
+        , ignore.stderr=TRUE, ignore.stdout=TRUE)
   # push files to the repository
-  check2 <- system(paste0("git push -f https://github.com/", repo, " ", ref)
-                   ,ignore.stderr=TRUE, ignore.stdout=TRUE)
+  system(paste0("git commit -m 'update'"), ignore.stderr=TRUE, ignore.stdout=TRUE)
+  system(paste0("git branch -M ",ref), ignore.stderr=TRUE, ignore.stdout=TRUE)
+  system(paste0("git remote add origin https://",token,"@github.com/",repo,".git")
+        , ignore.stderr=TRUE, ignore.stdout=TRUE)
+  check2 <- system(paste0("git push -f -u origin ",ref), ignore.stderr=TRUE, ignore.stdout=TRUE)
   setwd(cwd)
   return(check2)
 }

--- a/R/faasr_client_api_github-actions.R
+++ b/R/faasr_client_api_github-actions.R
@@ -426,7 +426,7 @@ faasr_register_workflow_git_remote_repo <- function(token,check,private,repo,ref
     }
   }
   # push files to the repository
-  check2 <- system(paste0("git push -f https://github.com/", repo, " ", ref),
+  check2 <- system(paste0("git push -f https://github.com/", repo, " ", ref)
                    ,ignore.stderr=TRUE, ignore.stdout=TRUE)
   setwd(cwd)
   return(check2)

--- a/R/faasr_client_api_github-actions.R
+++ b/R/faasr_client_api_github-actions.R
@@ -211,7 +211,7 @@ faasr_register_workflow_github_repo_question <- function(check, repo){
     cli_text("{symbol$fancy_question_mark}Enter repository visibility[private/public]")
     while(TRUE) {
       check <- invisible(readline())
-      if (check == "private") {
+      if (check == "private" || check == "") {
         private <- TRUE
         break
       } else if(check == "public") {
@@ -228,7 +228,7 @@ faasr_register_workflow_github_repo_question <- function(check, repo){
     cli_text("{symbol$fancy_question_mark} Update the repository?[y/n]")
     while(TRUE) {
       check1 <- readline()
-      if (check1=="y") {
+      if (check1=="y" || check1=="") {
         break
       } else if(check1 == "n") {
         cli_alert_danger("Stop the function")

--- a/R/faasr_client_api_github-actions.R
+++ b/R/faasr_client_api_github-actions.R
@@ -211,10 +211,10 @@ faasr_register_workflow_github_repo_question <- function(check, repo){
     cli_text("{symbol$fancy_question_mark}Enter repository visibility[private/public]")
     while(TRUE) {
       check <- invisible(readline())
-      if (check == "private" || check == "") {
+      if (check == "private") {
         private <- TRUE
         break
-      } else if(check == "public") {
+      } else if(check == "public" || check == "") {
         private <- FALSE
         break
       } else {

--- a/R/faasr_client_api_openwhisk.R
+++ b/R/faasr_client_api_openwhisk.R
@@ -199,7 +199,7 @@ faasr_register_workflow_openwhisk_check_user_input <- function(check, actionname
 
     while(TRUE) {
       check <- readline()
-      if (check=="y") {
+      if (check=="y" || check=="") {
         overwrite <- "true"
         break
       } else if(check=="n") {

--- a/R/faasr_client_tools.R
+++ b/R/faasr_client_tools.R
@@ -1,14 +1,3 @@
-#' @name faasr_register_workflow
-#' @title faasr_register_workflow
-#' @description 
-#' Client tools for registering actions
-#' This aggregates openwhisk, github actions and lambda's
-#' register functions
-#' @param ... inputs for timeout, cron, and memory
-#' @import cli
-#' @import httr
-#' @export 
-
 # define a list for storing functions
 .faasr_user <- list()
 
@@ -19,6 +8,17 @@ basic_gh_image <- "ghcr.io/faasr/github-actions-tidyverse:latest"
 basic_ow_image <- "faasr/openwhisk-tidyverse:latest"
 basic_ld_image_account <- "145342739029.dkr.ecr."
 basic_ld_image_tag <- ".amazonaws.com/aws-lambda-tidyverse:latest"
+
+#' @name faasr_register_workflow
+#' @title faasr_register_workflow
+#' @description 
+#' Client tools for registering actions
+#' This aggregates openwhisk, github actions and lambda's
+#' register functions
+#' @param ... inputs for timeout, cron, and memory
+#' @import cli
+#' @import httr
+#' @export 
 
 # faasr_register_workflow function
 faasr_register_workflow <- function(...){

--- a/R/faasr_delete_file.R
+++ b/R/faasr_delete_file.R
@@ -9,7 +9,6 @@
 #' @export
 
 globalVariables(".faasr")
-library("paws")
 
 # Default server_name is DefaultDataStore, default remote folder name is empty ("") and 
 # local folder name is current directory(".")

--- a/R/faasr_get_file.R
+++ b/R/faasr_get_file.R
@@ -12,7 +12,6 @@
 #' @export
 
 globalVariables(".faasr")
-library("paws")
 
 # Default server_name is DefaultDataStore, default remote folder name is empty ("") and 
 # local folder name is current directory(".")

--- a/R/faasr_init_log_folder.R
+++ b/R/faasr_init_log_folder.R
@@ -11,9 +11,6 @@
 #' @import paws
 #' @export
 
-library("uuid")
-library("paws")
-
 faasr_init_log_folder <- function(faasr) {
   # if InvocationID doesn't have valid form, generate a UUID
   if (length(faasr$InvocationID) == 0) {

--- a/R/faasr_lock.R
+++ b/R/faasr_lock.R
@@ -5,8 +5,6 @@
 #' @import paws
 #' @param faasr list with parsed and validated Payload
 
-library("paws")
-
 # Read-Set Memory implementation
 faasr_rsm <- function(faasr) {
   # Set env for flag and lock

--- a/R/faasr_log.R
+++ b/R/faasr_log.R
@@ -11,7 +11,6 @@
 #' @export
 
 globalVariables(".faasr")
-library("paws")
 
 faasr_log <- function(log_message) {
 

--- a/R/faasr_parse.R
+++ b/R/faasr_parse.R
@@ -11,9 +11,6 @@
 #' @import jsonvalidate
 #' @export
 
-library("jsonlite")
-library("jsonvalidate")
-
 faasr_parse <- function(faasr_payload) {
   faasr_schema <- readLines("FaaSr.schema.json")
 

--- a/R/faasr_put_file.R
+++ b/R/faasr_put_file.R
@@ -12,7 +12,6 @@
 #' @export
 
 globalVariables(".faasr")
-library("paws")
 
 # Default server_name is Logging Server, default remote folder name is empty ("") and 
 # local folder name is current directory(".")

--- a/R/faasr_run_user_function.R
+++ b/R/faasr_run_user_function.R
@@ -1,0 +1,46 @@
+#' @name faasr_run_user_function
+#' @title faasr_run_user_function
+#' @description 
+#' Run user functions and leave the state information
+#' @param .faasr list with parsed and validated Payload
+#' @export
+
+faasr_run_user_function <- function(.faasr){ 
+  
+  # If the Action reaches this point without aborting, it is ready to invoke the User Function
+  # Extract the name of the User Function from the Payload, and invoke it, passing the parsed Payload as arg
+  # try get(faasr$FunctionInvoke) and if there's an error, return error message and stop the function
+  func_name <- .faasr$FunctionList[[.faasr$FunctionInvoke]]$FunctionName
+  user_function = tryCatch(expr=get(func_name), error=function(e){
+    err_msg <- paste0('{\"faasr_user_function\":\"Cannot find Function ',func_name,', check the name and sources\"}', "\n")
+    cat(err_msg)
+    result <- faasr_log(err_msg)
+    stop()
+    }
+  )
+  
+  # Get a list of the current function's arguments.
+  user_args = faasr_get_user_function_args(.faasr)
+  
+  # Use do.call to use user_function with arguments
+  # try do.call and if there's an error, return error message and stop the function
+  faasr_result <- tryCatch(expr=do.call(user_function, user_args), error=function(e){
+    nat_err_msg <- paste0('\"faasr_user_function\":Errors in the user function ', as.character(e))
+    err_msg <- paste0('{\"faasr_user_function\":\"Errors in the user function: ',.faasr$FunctionInvoke,', check the log for the detail \"}', "\n")
+    result_2 <- faasr_log(nat_err_msg)
+    cat(err_msg)
+    stop()
+    }
+  )
+
+  # At this point, the Action has finished the invocation of the User Function
+  # We flag this by uploading a file with name FunctionInvoke.done with contents TRUE to the S3 logs folder
+  # Check if directory already exists. If not, create one
+  log_folder <- paste0(.faasr$FaaSrLog,"/",.faasr$InvocationID)
+  if (!dir.exists(log_folder)) {
+    dir.create(log_folder, recursive=TRUE)
+  }
+  file_name <- paste0(.faasr$FunctionInvoke, ".done")
+  write.table("TRUE", file=paste0(log_folder, "/", file_name), row.names=F, col.names=F)
+  faasr_put_file(local_folder=log_folder, local_file=file_name, remote_folder=log_folder, remote_file=file_name)
+}

--- a/R/faasr_s3_check.R
+++ b/R/faasr_s3_check.R
@@ -12,7 +12,6 @@
 #' 
 
 globalVariables(".faasr")
-library("paws")
 
 faasr_s3_check <- function(faasr){
 

--- a/R/faasr_s3_check.R
+++ b/R/faasr_s3_check.R
@@ -3,7 +3,7 @@
 #' @description 
 #' Check 
 #' 1. server's Endpoint&Region and Endpoint has a valid form(http).
-#' 2. send a req for the list of buckets to check the status of s3 stroage servers.
+#' 2. send a req for the list of buckets to check the status of s3 servers.
 #' 3. Check that the bucket name exists.
 #' @param faasr list with parsed and validated Payload
 #' @return faasr list with parsed and validated payload

--- a/R/faasr_trigger.R
+++ b/R/faasr_trigger.R
@@ -12,11 +12,6 @@
 #' @import paws
 #' @export
 
-library("jsonlite")
-library("httr")
-library("paws")
-
-
 faasr_trigger <- function(faasr) {
 
   # First extract the name of the user function

--- a/vignettes/faasr.Rmd
+++ b/vignettes/faasr.Rmd
@@ -60,13 +60,13 @@ Without FaaS, deploying and managing such kinds of workflows is time-consuming, 
 
 With FaaS, it is possible to enable individual researchers and small teams to deploy such workflows without managing servers, bringing cloud capabilities closer to a wider range of researchers and applications. However, there are still challenges:
 
-* There is a significant learning curve in using the APIs (Application Programming Interfces) of FaaS platforms
+* There is a significant learning curve in using the APIs (Application Programming Interfaces) of FaaS platforms
 
 * Different FaaS platforms use different, incompatible APIs; developing for one platform can lead to vendor lock-in over time
 
 * Typically, FaaS platforms have native support for languages such as Python and Javascript, whereas many applications in the scientific community are written in R
 
-* FaaS execution is "stateless" whereby all the data that a function uses/creates in runtimemust be downloaded/uploaded to cloud data storage external to the FaaS platform
+* FaaS execution is "stateless" whereby all the data that a function uses/creates in runtime must be downloaded/uploaded to cloud data storage external to the FaaS platform
 
 FaaSr supports the science use cases by addressing these challenges:
 


### PR DESCRIPTION
1. Divide "faasr_start"
- Now, faasr_start contains "faasr_parse", "faasr_check_workflow", "faasr_s3_check", "faasr_init_log", "faasr_abort"
- running user function and trigger next invocation will be separately managed.
- "faasr_run_user_function" is now executing the user function and leave the state info.

2. Edit for CRAN submission
- get rid of "library" - following the recommendation of "good practice"

3. Bug fix
- Asking user input("readline()") now can be handled on the non-interactive interface. - default is designated.
- AWS Lambda register functions now returns empty list instead of checking the whole process + modulization.
- "git push" can be handled in any environment - including testing env. 

4. Typo fix
- Some typos detected by "devtools::spell_check()"