### PR TITLE
Issue#71 - Write per-action logs in faasr_log

### DIFF
--- a/R/faasr_abort_on_multiple_invocations.R
+++ b/R/faasr_abort_on_multiple_invocations.R
@@ -60,7 +60,6 @@ faasr_abort_on_multiple_invocations <- function(faasr, pre) {
     if (!func_done %in% check_fn_done_list){
       res_msg <- paste0('{\"faasr_abort_on_multiple_invocations\":\"not the last trigger invoked - no flag\"}', "\n")
       message(res_msg)
-      faasr_log(res_msg)
       stop()
     }
   }
@@ -117,7 +116,6 @@ faasr_abort_on_multiple_invocations <- function(faasr, pre) {
   } else {
     res_msg <- paste0('{\"faasr_abort_on_multiple_invocations\":\"not the last trigger invoked - random number does not match\"}', "\n")
     message(res_msg)
-    faasr_log(res_msg)
     stop()
   }
 }


### PR DESCRIPTION
As for second idea, actions that are aborted will not leave the log to the bucket (It will still leave the message on the FaaS platforms)