### PR TITLE
fix: preserve leading slash in local absolute paths

### DIFF
--- a/R/faasr_get_file.R
+++ b/R/faasr_get_file.R
@@ -47,7 +47,8 @@ faasr_get_file <- function(server_name=.faasr$DefaultDataStore, remote_folder=""
   }
 
   # takes same way with remote folder & file
-  local_folder <- sub("^/+", "", sub("/+$", "", local_folder))
+  local_folder <- sub("/+$", "", local_folder)  # First remove trailing slashes
+  local_folder <- sub("^/+", "/", local_folder) # Replace multiple leading slashes with single slash
   local_file <- sub("^/+", "", sub("/+$", "", local_file))
   get_file <- paste0(local_folder,"/",local_file)
    

--- a/R/faasr_put_file.R
+++ b/R/faasr_put_file.R
@@ -48,10 +48,11 @@ faasr_put_file <- function(server_name=.faasr$DefaultDataStore, local_folder="."
     put_file <- local_file
   # If not, takes same way with remote folder & file
   } else{
-    local_folder <- sub("^/+", "", sub("/+$", "", local_folder))
+    local_folder <- sub("/+$", "", local_folder)  # First remove trailing slashes
+    local_folder <- sub("^/+", "/", local_folder) # Replace multiple leading slashes with single slash
     local_file <- sub("^/+", "", sub("/+$", "", local_file))
     put_file <- paste0(local_folder,"/",local_file)
-  }  
+  }
  
   s3 <- paws.storage::s3(
 	  config=list(


### PR DESCRIPTION
## Title: "Fix: Preserve leading slash in local absolute paths"

## Description:
This PR fixes the handling of local absolute paths in `faasr_get_file` and `faasr_put_file` functions.

## Changes made:
- Modified path handling to preserve leading slash for local absolute paths
- Maintains existing behavior for relative paths
- Keeps current S3 remote path handling unchanged

## Example:
Before:
- "/tmp/xyz" -> "tmp/xyz"
- "///tmp/xyz" -> "tmp/xyz"

After:
- "/tmp/xyz" -> "/tmp/xyz"
- "///tmp/xyz" -> "/tmp/xyz"
- "tmp/xyz" -> "tmp/xyz" (unchanged)