### PR TITLE
[Issue #89] Support invocation of multiple concurrent actions

### DIFF
--- a/R/faasr_client_api_github-actions.R
+++ b/R/faasr_client_api_github-actions.R
@@ -13,6 +13,7 @@ jobs:
     env:
       SECRET_PAYLOAD: ${{ secrets.SECRET_PAYLOAD }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      PAYLOAD_REPO: ${{ vars.PAYLOAD_REPO }}
       PAYLOAD: ${{ github.event.inputs.PAYLOAD }}
     steps:
     - name: run Rscript
@@ -37,6 +38,7 @@ jobs:
     env:
       SECRET_PAYLOAD: ${{ secrets.SECRET_PAYLOAD }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      PAYLOAD_REPO: ${{ vars.PAYLOAD_REPO }}
       PAYLOAD: ${{ github.event.inputs.PAYLOAD }}
     steps:
     - name: run Rscript

--- a/R/faasr_client_api_github-actions.R
+++ b/R/faasr_client_api_github-actions.R
@@ -534,7 +534,29 @@ faasr_register_workflow_git_remote_env <- function(repo, cred, token){
     setwd(cwd)
     stop()
   }
-
+  
+  # set the repo variable
+  url <- paste0("repos/",repo,"/actions/variables")
+  body <- list(name="PAYLOAD_REPO", value=paste0(repo,'/payload.json'))
+  response <- faasr_httr_request(body=body, token=token, url=url, type="POST")
+  if (response$status_code==201){
+    cli_alert_success("Successfully set variables")
+  } else if (response$status_code==409){
+    # if variable already exists, update the variable
+    url <- paste0("repos/",repo,"/actions/variables/PAYLOAD_REPO")
+    response <- faasr_httr_request(body=body, token=token, url=url, type="PATCH")
+    if (response$status_code==204){
+      cli_alert_success("Successfully set variables")
+    } else {
+      cli_alert_danger("Error: Failed to set variables")
+      setwd(cwd)
+      stop()
+    }
+  } else {
+    cli_alert_danger("Error: Failed to set variables")
+    setwd(cwd)
+    stop()
+  }
   setwd(cwd)
 }
 

--- a/R/faasr_client_api_github-actions.R
+++ b/R/faasr_client_api_github-actions.R
@@ -102,7 +102,7 @@ faasr_register_workflow_github_actions <- function(faasr, cred, cron=NULL, runne
     faasr_register_workflow_github_create_env(server,repo)
     cli_alert_success("Create github env files")
     # create the payload file
-    #faasr_register_workflow_github_create_payload(faasr,repo)
+    faasr_register_workflow_github_create_payload(faasr,repo)
     #cli_alert_success("Create github payload file")
     # create the README file
     faasr_register_workflow_github_create_readme(repo)


### PR DESCRIPTION
1. Github actions use Payload from both the repository and R console.
- Payload are sent from R console.
- If no payload found in the container, FaaSr pulls it from the repository.