### PR TITLE
Add GCP Support for FaaSr Platform Using Cloud Run Jobs and Google Cloud Scheduler

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Description: Allows users to create and deploy the workflow with multiple functi
     Apache OpenWhisk <https://openwhisk.apache.org/>
     GitHub Actions <https://github.com/features/actions>
     Amazon Web Services (AWS) Lambda <https://aws.amazon.com/lambda/>
+    Google Cloud Platform (GCP) Cloud Run <https://cloud.google.com/run>
     Supported cloud data storage for persistent storage:
     Amazon Web Services (AWS) Simple Storage Service (S3) <https://aws.amazon.com/s3/>.
 License: MIT + file LICENSE

--- a/R/faasr_client_api_google_cloud.R
+++ b/R/faasr_client_api_google_cloud.R
@@ -66,9 +66,10 @@ faasr_register_workflow_google_cloud <- function(faasr, cred, ssl=TRUE, memory=1
   cli_text(col_cyan("{symbol$menu} {.strong Successfully registered all google cloud actions}"))
 }
 
+
 #' @title faasr_gcp_httr_request
 #' @description 
-#' unction to send the curl request to the google cloud run api
+#' function to send the curl request to the google cloud run api
 #' by using the "httr" library. 
 #' @param faasr a list form of the JSON file
 #' @param server a string for the target server
@@ -77,7 +78,7 @@ faasr_register_workflow_google_cloud <- function(faasr, cred, ssl=TRUE, memory=1
 #' @param body a list of body
 #' @param ssl SSL CA check; for the SSL certificate: FALSE
 #' @param namespace a string for the specific namespace e.g., /whisk.system
-#' @return an integer value for the response
+#' @return response object from the google cloud run api
 #' @import httr
 #' @import cli
 #' @keywords internal
@@ -126,7 +127,6 @@ faasr_gcp_httr_request <- function(faasr, server, action, type, body=NULL, ssl=T
 }
 
 
-
 #' @title faasr_gcp_cloud_scheduler_httr_request
 #' @description 
 #' function to send the curl request to the google cloud scheduler
@@ -138,7 +138,7 @@ faasr_gcp_httr_request <- function(faasr, server, action, type, body=NULL, ssl=T
 #' @param body a list of body
 #' @param ssl SSL CA check; for the SSL certificate: FALSE
 #' @param namespace a string for the specific namespace e.g., /whisk.system
-#' @return an integer value for the response
+#' @return response object from the google cloud run api
 #' @import httr
 #' @import cli
 #' @keywords internal
@@ -226,7 +226,7 @@ faasr_register_workflow_google_cloud_action_lists <- function(faasr) {
 #' Check the remote repository is existing on the google cloud
 #' by sending the GET request.
 #' If it exists, return TRUE, doesn't exist, return FALSE
-#' @param action a string for the target action: /actions, /triggers, /rules
+#' @param action a string for the target action
 #' @param server a string for the target server
 #' @param faasr a list form of the JSON file
 #' @param all_jobs a list of all existing gcloud jobs
@@ -293,8 +293,8 @@ faasr_register_workflow_google_cloud_check_user_input <- function(check, actionn
 #' @param actionname a string for the target action name
 #' @param server a string for the target server
 #' @param faasr a list form of the JSON file
-#' @param memory an integer for the max size of memory
-#' @param timeout an integer for the max length of timeout
+#' @param memory an integer for the max size of memory (MB)
+#' @param timeout an integer for the max length of timeout (seconds)
 #' @param check a logical value for target existence
 #' @import httr
 #' @import cli

--- a/R/faasr_client_api_google_cloud.R
+++ b/R/faasr_client_api_google_cloud.R
@@ -1,0 +1,538 @@
+#' @name faasr_register_workflow_google_cloud
+#' @title faasr_register_workflow_google_cloud
+#' @description 
+#' register the workflow for google cloud.
+#' parse faasr to get the server list and actions.
+#' create a actions for the FaaSr actions.
+#' @param faasr a list form of the JSON file
+#' @param cred a list form of the credentials
+#' @param ssl SSL CA check; for the SSL certificate: FALSE
+#' @param memory an integer for the max size of memory
+#' @param timeout an integer for the max length of timeout
+#' @import httr
+#' @import cli
+#' @keywords internal
+
+faasr_register_workflow_google_cloud <- function(faasr, cred, ssl=TRUE, memory=1024, timeout=86400, storage=NULL) {
+  
+  options(cli.progress_clear = FALSE)
+  options(cli.spinner = "line")
+
+  # create a server-action set
+  action_list <- faasr_register_workflow_google_cloud_action_lists(faasr)
+
+  if (length(action_list)==0){
+    return("")
+  }
+
+  # check servers and actions, create actions
+  for (server in names(action_list)) {
+
+    cli::cli_h1(paste0("Registering workflow for google cloud: ", server))
+    cli::cli_progress_bar(
+      format = paste0(
+        "FaaSr {pb_spin} Registering workflow google cloud ",
+        "{cli::pb_bar} {cli::pb_percent} [{pb_current}/{pb_total}]   ETA:{pb_eta}"
+      ),
+      format_done = paste0(
+        "{col_yellow(symbol$checkbox_on)} Successfully registered actions for server {server} ",
+        "in {pb_elapsed}."
+      ),
+      total = length(action_list[[server]]) * 2 + 1
+    )
+
+    faasr <- faasr_replace_values(faasr, cred)
+
+    response <- faasr_gcp_httr_request(faasr, server, "/jobs", type="GET", ssl=ssl)
+
+    if (response$status_code==200 || response$status_code==202){
+        all_gcloud_jobs <- content(response)$jobs
+        succ_msg <- paste0("All exising gcloud jobs fetched: ", length(content(response)$jobs), " jobs")
+        cli_alert_success(succ_msg)
+        cli_progress_update()
+    } else {
+        err_msg <- paste0("Error fetching all exising gcloud jobs: ", content(response)$error)
+        cli_alert_danger(err_msg)
+        stop()
+    }
+
+    for (action in action_list[[server]]) {
+      check <- faasr_register_workflow_google_cloud_check_exists(action, server, faasr, all_gcloud_jobs)
+      cli_progress_update()
+      faasr_register_workflow_google_cloud_create_action(ssl, action, server, faasr,  memory, timeout, check)
+      cli_progress_update()
+    }
+  }
+  cli_text(col_cyan("{symbol$menu} {.strong Successfully registered all google cloud actions}"))
+}
+
+#' @title faasr_gcp_httr_request
+#' @description 
+#' the help function to send the curl request to the google cloud
+#' by using the "httr" library. 
+#' @param faasr a list form of the JSON file
+#' @param server a string for the target server
+#' @param action a string for the target action: /actions, /triggers, /rules
+#' @param type REST API values; GET/PUT/DELETE/PATCH/POST
+#' @param body a list of body
+#' @param ssl SSL CA check; for the SSL certificate: FALSE
+#' @param namespace a string for the specific namespace e.g., /whisk.system
+#' @return an integer value for the response
+#' @import httr
+#' @import cli
+#' @keywords internal
+
+# help sending httr requests
+faasr_gcp_httr_request <- function(faasr, server, action, type, body=NULL, ssl=TRUE, namespace=NULL){
+
+  endpoint <- faasr$ComputeServers[[server]]$Endpoint
+  if (!startsWith(endpoint, "https://")){
+    endpoint <- paste0("https://", endpoint)
+  }
+  if (is.null(namespace)){
+    namespace <- faasr$ComputeServers[[server]]$Namespace
+  }
+  region <- faasr$ComputeServers[[server]]$Region
+  endpoint <- paste0(endpoint, namespace, "/locations/", region, action)
+
+  if (!is.null(faasr$ComputeServers[[server]]$SSL) && length(faasr$ComputeServers[[server]]$SSL)!=0){
+      ssl <- as.logical(toupper(faasr$ComputeServers[[server]]$SSL))
+  }
+  
+  token <- faasr$ComputeServers[[server]]$AccessKey
+
+  # get functions depending on "type"
+  func <- get(type)
+
+  # write headers
+  headers <- c(
+    'accept' = 'application/json',
+    'Content-Type' = 'application/json',
+    'Authorization' = paste("Bearer", token)
+  )
+
+  print(paste("Sending request to", endpoint))
+  # send the REST request (POST/GET/DELETE) with timeout
+  response <- func(
+    url = endpoint,
+    add_headers(.headers = headers),
+    body = body,
+    encode = "json",
+    httr::config(ssl_verifypeer = ssl, ssl_verifyhost = ssl),
+    accept_json()
+  )
+
+  return(response)
+}
+
+
+#' @title faasr_register_workflow_google_cloud_action_lists
+#' @description 
+#' Parse the faasr and get the list of function:server
+#' Find actions which is using "GoogleCloud"
+#' return value's key is action and value is server name.
+#' @param faasr a list form of the JSON file
+#' @return an list of "action name: server name" pairs
+#' @import httr
+#' @import cli
+#' @keywords internal
+
+faasr_register_workflow_google_cloud_action_lists <- function(faasr) {
+  # empty list
+  action_list <- list()
+  # for each function, iteratively collect server names and action names
+  for (fn in names(faasr$FunctionList)) {
+    server_name <- faasr$FunctionList[[fn]]$FaaSServer
+    # if FaaStype is GoogleCloud, add it to the list
+    if (is.null(faasr$ComputeServers[[server_name]]$FaaSType)){
+      err_msg <- paste0("Invalid server:", server_name," check server type")
+      cli_alert_danger(err_msg)
+      stop()
+    }
+    if (faasr$ComputeServers[[server_name]]$FaaSType == "GoogleCloud") {
+      action_name <- fn
+      action_list[[server_name]] <- unique(c(action_list[[server_name]],action_name))
+    }
+  }
+  return(action_list)
+}
+
+
+#' @title faasr_register_workflow_google_cloud_check_exists
+#' @description 
+#' Check the remote repository is existing on the google cloud
+#' by sending the GET request.
+#' If it exists, return TRUE, doesn't exist, return FALSE
+#' @param action a string for the target action: /actions, /triggers, /rules
+#' @param server a string for the target server
+#' @param faasr a list form of the JSON file
+#' @param all_gcloud_jobs a list of all existing gcloud jobs
+#' @return a logical value; if exists, return TRUE, 
+#' doesn't exist, return FALSE
+#' @import cli
+#' @keywords internal
+
+faasr_register_workflow_google_cloud_check_exists <- function(action, server, faasr, all_gcloud_jobs){
+
+  current_job_name <- paste0("projects/", faasr$ComputeServers[[server]]$Namespace, "/locations/", faasr$ComputeServers[[server]]$Region, "/jobs/", action)
+  for(job in all_gcloud_jobs)
+  {
+    if(job$name == current_job_name)
+    {
+      succ_msg <- paste0("Check ", action, " exists: TRUE - Found")
+      cli_alert_warning(succ_msg)
+      return(TRUE)
+    }
+  }
+  alert_msg <- paste0("Check ", action, " exists: FALSE - Create New")
+  cli_alert_success(alert_msg)
+  return(FALSE)
+}
+
+
+#' @title faasr_register_workflow_google_cloud_check_delete_job_user_input
+#' @description 
+#' Ask user input for the google cloud
+#' @param check a logical value for target existence
+#' @param actionname a string for the target action name
+#' @return a logical value for delete
+#' @import cli
+#' @keywords internal
+
+faasr_register_workflow_google_cloud_check_delete_job_user_input <- function(check, actionname){
+  # if given values already exists, ask the user to update the action
+  delete_job <- FALSE
+  if (check){
+    cli_alert_info(paste0("Do you want to delete and create the job?[y/n]"))
+
+    while(TRUE) {
+      check <- readline()
+      if (check=="y" || check=="") {
+        delete_job <- TRUE
+        break
+      } else if(check=="n") {
+        stop()
+      } else {
+        cli_alert_warning("Enter \"y\" or \"n\": ")
+      }
+    }
+  }
+  return(delete_job)
+}
+
+
+#' @title faasr_register_workflow_google_cloud_check_create_job_user_input
+#' @description 
+#' Ask user input for the google cloud
+#' @param actionname a string for the target action name
+#' @import cli
+#' @keywords internal
+
+faasr_register_workflow_google_cloud_check_create_job_user_input <- function(actionname){
+  # if given values already exists, ask the user to update the action
+    cli_alert_info(paste0("Proceed to create the job - ", actionname, "?[y/n]"))
+
+    while(TRUE) {
+      check <- readline()
+      if (check=="y" || check=="") {
+        break
+      } else if(check=="n") {
+        err_msg <- paste0("Google cloud job creation cancelled for the function - ", actionname)
+        cli_alert_danger(err_msg)
+        stop()
+      } else {
+        cli_alert_warning("Enter \"y\" or \"n\": ")
+      }
+    }
+}
+
+#' @title faasr_register_workflow_google_cloud_create_action
+#' @description 
+#' Create an action
+#' if it already exists and user wants, update the action
+#' @param ssl SSL CA check; for the SSL certificate: FALSE
+#' @param actionname a string for the target action name
+#' @param server a string for the target server
+#' @param faasr a list form of the JSON file
+#' @param memory an integer for the max size of memory
+#' @param timeout an integer for the max length of timeout
+#' @param check a logical value for target existence
+#' @import httr
+#' @import cli
+#' @keywords internal
+
+# create an action
+faasr_register_workflow_google_cloud_create_action <- function(ssl, actionname, server, faasr, memory, timeout, check) {
+  
+  delete_job <- faasr_register_workflow_google_cloud_check_delete_job_user_input(check, actionname)
+  if (delete_job){
+    # delete the gcloud job
+    action <- paste0("/jobs/", actionname)
+    response <- faasr_gcp_httr_request(faasr, server, action, type="DELETE")
+    if (response$status_code==200 || response$status_code==202){
+      succ_msg <- paste0("Successfully deleted gcloud job for the function - ", actionname)
+      cli_alert_success(succ_msg)
+      faasr_register_workflow_google_cloud_check_create_job_user_input(actionname)
+    } else {
+      err_msg <- paste0("Error deleting gcloud job for the function - ", actionname, ": ", content(response)$error)
+      cli_alert_danger(err_msg)
+      stop()
+    }
+  }
+
+  # actioncontainer can be either default or user-customized
+  if (length(faasr$ActionContainers[[actionname]])==0 || faasr$ActionContainers[[actionname]] == "") {
+    actioncontainer <- "gcr.io/faasr/google-cloud-tidyverse:latest"
+  } else {
+    actioncontainer <- faasr$ActionContainers[[actionname]]
+  }
+  # create a function with maximum timeout and 512MB memory space
+
+  body <- list(
+    template = list(
+      template = list(
+        containers = list(
+          list(
+            image = actioncontainer,
+            resources = list(
+              limits = list(
+                memory = paste0(memory, "Mi")
+              )
+            )
+          )
+        ),
+        timeout = paste0(timeout, "s") # Set service timeout (e.g., "24 * 60 * 60 s" for 24 hours)
+      )
+    )
+  )
+
+  action <- paste0("/jobs?jobId=", actionname)
+  response <- faasr_gcp_httr_request(faasr, server, action, type="POST", body=body, ssl)
+  if (response$status_code==200 || response$status_code==202){
+    succ_msg <- paste0("Successfully created gcloud job for the function - ", actionname)
+    cli_alert_success(succ_msg)
+  } else {
+    err_msg <- paste0("Error in creating gcloud job for the function - ", actionname, ": ", content(response)$error)
+    cli_alert_danger(err_msg)
+    stop()
+  }
+  
+}
+
+
+#' @title faasr_workflow_invoke_google_cloud
+#' @description 
+#' Invoke a workflow for the google cloud
+#' this function is invoked by faasr_workflow_invoke
+#' @param faasr a list form of the JSON file
+#' @param cred a list form of the credentials
+#' @param faas_name a string for the target server
+#' @param actionname a string for the target action name
+#' @param ssl SSL CA check; for the SSL certificate: FALSE
+#' @import httr
+#' @import cli
+#' @keywords internal
+
+faasr_workflow_invoke_google_cloud <- function(faasr, cred, faas_name, actionname, ssl=TRUE){
+
+  action <- paste0("/jobs/", actionname, ":run")
+  faasr <- faasr_replace_values(faasr, cred)
+
+  # Prepare the args from the faasr object
+  args <- jsonlite::toJSON(faasr, auto_unbox = TRUE)
+
+  # Build the body for the HTTP request without specifying the image
+  body <- list(
+    overrides = list(
+      containerOverrides = list(
+        list(
+          args = args
+        )
+      )
+      # taskCount = 1, # Configures as per need while invoking the job
+      # timeout = paste0(service_timeout_seconds, "s")  # Set service timeout
+    )
+  )
+  
+  response <- faasr_gcp_httr_request(faasr, faas_name, action, type="POST", body=body, ssl)
+  if (response$status_code==200 || response$status_code==202){
+    succ_msg <- paste0("Successfully invoke the function - ", actionname)
+    cli_alert_success(succ_msg)
+  } else {
+    err_msg <- paste0("Error invoke the function - ", actionname, ": ", content(response)$error)
+    cli_alert_danger(err_msg)
+    stop()
+  }
+
+}
+
+
+# #' @title faasr_set_workflow_timer_google_cloud
+# #' @description 
+# #' # set/unset workflow cron timer for google cloud
+# #' @param faasr a list form of the JSON file
+# #' @param cred a list form of the credentials
+# #' @param target a string for the target action
+# #' @param cron a string for cron data e.g., */5 * * * *
+# #' @param unset a logical value; set timer(FALSE) or unset timer(TRUE)
+# #' @param ssl SSL CA check; for the SSL certificate: FALSE
+# #' @import httr
+# #' @import cli
+# #' @keywords internal
+
+# # set workflow timer for google cloud
+# faasr_set_workflow_timer_gcp <- function(faasr, cred, target, cron, unset=FALSE, ssl=TRUE){
+
+#   # set variables
+#   server <- faasr$FunctionList[[target]]$FaaSServer
+#   trigger_name <- paste0(target,"_trigger")
+#   rule_name <- paste0(target,"_rule")
+#   api_key <- faasr$ComputeServers[[server]]$API.key
+#   namespace <- faasr$ComputeServers[[server]]$Namespace
+
+#   # json should get out two layers, so escaping letter should be twice
+#   faasr <- faasr_replace_values(faasr, cred)
+   
+#   # if unset==TRUE, delete the rule and trigger
+#   if (unset==TRUE){
+#     action <- paste0("triggers/", trigger_name) 
+#     check <- faasr_register_workflow_google_cloud_check_exists(ssl, action, server,faasr)
+    
+#     overwrite <- faasr_register_workflow_google_cloud_check_user_input(check, trigger_name, type="trigger")
+#     if (overwrite == "true"){
+#       action_performed <- "Create"
+#     } else{
+#       action_performed <- "Update"
+#     }
+
+#     action <- paste0(action, "?overwrite=",overwrite)
+#     response <- faasr_gcp_httr_request(faasr, server, action, type="PUT", ssl)
+#     ####response handling: status code
+#     if (response$status_code==200 || response$status_code==202){
+#       succ_msg <- paste0("Successfully ", action_performed," the trigger - ", trigger_name)
+#       cli_alert_success(succ_msg)
+#     } else {
+#       err_msg <- paste0("Error  ", action_performed," the trigger - ", trigger_name,": ",content(response)$error)
+#       cli_alert_danger(err_msg)
+#       stop()
+#     }
+
+#     ## fire the alarm
+#     namespace_system <- "whisk.system"
+#     action <- paste0("actions/alarms/alarm?blocking=false&result=false")
+#     body <- list(
+#       authKey = api_key,
+#       cron = cron,
+#       trigger_payload = faasr,
+#       lifecycleEvent = "CREATE",
+#       triggerName = trigger_name
+#     )
+#     response <- faasr_gcp_httr_request(faasr, server, action, type="POST", body=body, ssl, namespace=namespace_system)
+#     ####response handling: status code
+#     if (response$status_code==200 || response$status_code==202){
+#       succ_msg <- paste0("Successfully fire the alarm")
+#       cli_alert_success(succ_msg)
+#     } else {
+#       err_msg <- paste0("Error fire the alarm: ",content(response)$error)
+#       cli_alert_danger(err_msg)
+#       stop()
+#     }
+
+#     # check the rule
+#     action <- paste0("rules/", rule_name) 
+#     check <- faasr_register_workflow_google_cloud_check_exists(ssl, action, server,faasr)
+    
+#     overwrite <- "true"
+    
+#     # create the rule
+#     action <- paste0(action, "?overwrite=",overwrite)
+#     body <- list(
+#       name = rule_name,
+#       status = "",
+#       trigger = paste0("/", namespace, "/", trigger_name),
+#       action = paste0("/", namespace, "/", target)
+#     )
+#     response <- faasr_gcp_httr_request(faasr, server, action, type="PUT", body=body, ssl)
+#     ####response handling: status code
+#     if (response$status_code==200 || response$status_code==202){
+#       succ_msg <- paste0("Successfully ", action_performed," the rule - ", rule_name)
+#       cli_alert_success(succ_msg)
+#     } else {
+#       err_msg <- paste0("Error  ", action_performed," the rule - ", rule_name,": ",content(response)$error)
+#       cli_alert_danger(err_msg)
+#       stop()
+#     }
+
+
+#   # if unset=FALSE, set the rule and trigger
+#   } else {
+    
+#     action <- paste0("triggers/", trigger_name) 
+#     check <- faasr_register_workflow_google_cloud_check_exists(ssl, action, server,faasr)
+#     if (!check){
+#       err_msg <- paste0("Error: No ",trigger_name," found")
+#       cli_alert_danger(err_msg)
+#       stop()
+#     }
+    
+#     ## stop the alarm
+#     namespace <- "whisk.system"
+#     action <- paste0("actions/alarms/alarm?blocking=false&result=false")
+#     body <- list(
+#       authKey = api_key,
+#       lifecycleEvent = "DELETE",
+#       triggerName = trigger_name
+#     )
+#     response <- faasr_gcp_httr_request(faasr, server, action, type="POST", body=body, ssl, namespace=namespace)
+#     ####response handling: status code
+#     if (response$status_code==200 || response$status_code==202){
+#       succ_msg <- paste0("Successfully Stop the alarm")
+#       cli_alert_success(succ_msg)
+#     } else {
+#       err_msg <- paste0("Error Stop the alarm: ",content(response)$error)
+#       cli_alert_danger(err_msg)
+#       stop()
+#     }
+
+#     # delete the trigger
+#     action <- paste0("triggers/", trigger_name) 
+#     response <- faasr_gcp_httr_request(faasr, server, action, type="DELETE", ssl)
+#     ####response handling: status code
+#     if (response$status_code==200 || response$status_code==202){
+#       succ_msg <- paste0("Successfully Delete the trigger - ", trigger_name)
+#       cli_alert_success(succ_msg)
+#     } else {
+#       err_msg <- paste0("Error Delete the trigger - ", trigger_name,": ",content(response)$error)
+#       cli_alert_danger(err_msg)
+#       stop()
+#     }
+
+
+#     # check the rule
+#     action <- paste0("rules/", rule_name) 
+#     check <- faasr_register_workflow_google_cloud_check_exists(ssl, action, server,faasr)
+#     if (!check){
+#       err_msg <- paste0("Error: No ",rule_name," found")
+#       cli_alert_danger(err_msg)
+#       stop()
+#     }
+    
+#     # disable the rule
+#     action <- paste0(action, "?overwrite=true")
+#     body <- list(
+#       status = "inactive",
+#       trigger = "null",
+#       action = "null"
+#     )
+#     response <- faasr_gcp_httr_request(faasr, server, action, type="POST", body=body, ssl)
+#     ####response handling: status code
+#     if (response$status_code==200 || response$status_code==202){
+#       succ_msg <- paste0("Successfully Delete the rule - ", rule_name)
+#       cli_alert_success(succ_msg)
+#     } else {
+#       err_msg <- paste0("Error Delete the rule - ", rule_name,": ",content(response)$error)
+#       cli_alert_danger(err_msg)
+#       stop()
+#     }
+#   }
+# }

--- a/R/faasr_client_tools.R
+++ b/R/faasr_client_tools.R
@@ -561,8 +561,7 @@ faasr_set_workflow_timer <- function(cron, target=NULL, ...){
   } else if (type == "OpenWhisk"){
     faasr_set_workflow_timer_ow(faasr,cred,target,cron, ...)
   } else if (type == "GoogleCloud"){
-    #faasr_set_workflow_timer_gcp(faasr,cred,target,cron, ...)
-    print("Google Cloud timer to be implemented")
+    faasr_set_workflow_timer_gcp(faasr,cred,target,cron, ...)
   }
 }
 .faasr_user$operations$set_workflow_timer <- faasr_set_workflow_timer
@@ -613,8 +612,7 @@ faasr_unset_workflow_timer <- function(target=NULL,...){
   } else if (type == "OpenWhisk"){
     faasr_set_workflow_timer_ow(faasr,cred,target, cron=NULL, unset=TRUE,...)
   } else if (type == "GoogleCloud"){
-    #faasr_set_workflow_timer_gcp(faasr,cred,target, cron=NULL, unset=TRUE,...)
-    print("Google Cloud timer to be implemented")
+    faasr_set_workflow_timer_gcp(faasr,cred,target, cron=NULL, unset=TRUE,...)
   }
 }
 .faasr_user$operations$unset_workflow_timer <- faasr_unset_workflow_timer

--- a/R/faasr_trigger.R
+++ b/R/faasr_trigger.R
@@ -77,7 +77,11 @@ faasr_trigger <- function(faasr) {
             # Set the env values for the google cloud action.
             # GoogleCloud API handling
             endpoint <- faasr$ComputeServers[[next_server]]$Endpoint
-            token <- faasr$ComputeServers[[next_server]]$API.key
+            namespace <- faasr$ComputeServers[[next_server]]$Namespace
+            region <- faasr$ComputeServers[[next_server]]$Region
+            endpoint <- paste0(endpoint, namespace, "/locations/", region, "/jobs/faasrjob:run")
+
+            token <- faasr$ComputeServers[[next_server]]$AccessKey
 
             if (is.null(faasr$ComputeServers[[next_server]]$SSL) || faasr$ComputeServers[[next_server]]$SSL == "") {
               ssl <- TRUE
@@ -91,11 +95,25 @@ faasr_trigger <- function(faasr) {
               'Authorization' = paste("Bearer", token)  # Set Authorization header directly
             )
 
+            # Prepare the args from the faasr object
+            args <- toJSON(faasr, auto_unbox = TRUE)
+            # Build the body for the HTTP request without specifying the image
+            body <- list(
+              overrides = list(
+                containerOverrides = list(
+                  list(
+                    args = args
+                  )
+                )
+                # taskCount = 1, (Can be set if needed)
+                # timeout = paste0(service_timeout_seconds, "s")  # Set service timeout
+              )
+            )
             # Send the REST request (POST/GET/PUT/PATCH)
             response <- POST(
               url = endpoint,
               add_headers(.headers = headers),
-              body = faasr,
+              body = body,
               encode = "json",
               httr::config(ssl_verifypeer = ssl, ssl_verifyhost = ssl),
               accept_json()
@@ -104,11 +122,11 @@ faasr_trigger <- function(faasr) {
             if (response$status_code == 200 || response$status_code == 202) {
               succ_msg <- paste0('{\"faasr_trigger\":\"GoogleCloud: Successfully invoked: ', faasr$FunctionInvoke, '\"}\n')
               message(succ_msg)
-              #faasr_log(succ_msg) # TODO: Add this back in
+              faasr_log(succ_msg)
             } else {
-              #err_msg <- paste0('{\"faasr_trigger\":\"GoogleCloud: Error invoking: ', faasr$FunctionInvoke, ' - ', content(response)$error, '\"}\n')
+              err_msg <- paste0('{\"faasr_trigger\":\"GoogleCloud: Error invoking: ', faasr$FunctionInvoke, '\"}\n')
               message(response)
-              #faasr_log(err_msg) # TODO: Add this back in
+              faasr_log(err_msg)
             }
           },
           # if OpenWhisk - use OpenWhisk API

--- a/R/faasr_trigger.R
+++ b/R/faasr_trigger.R
@@ -106,8 +106,8 @@ faasr_trigger <- function(faasr) {
               message(succ_msg)
               #faasr_log(succ_msg) # TODO: Add this back in
             } else {
-              err_msg <- paste0('{\"faasr_trigger\":\"GoogleCloud: Error invoking: ', faasr$FunctionInvoke, ' - ', content(response)$error, '\"}\n')
-              message(err_msg)
+              #err_msg <- paste0('{\"faasr_trigger\":\"GoogleCloud: Error invoking: ', faasr$FunctionInvoke, ' - ', content(response)$error, '\"}\n')
+              message(response)
               #faasr_log(err_msg) # TODO: Add this back in
             }
           },

--- a/R/faasr_trigger.R
+++ b/R/faasr_trigger.R
@@ -79,7 +79,8 @@ faasr_trigger <- function(faasr) {
             endpoint <- faasr$ComputeServers[[next_server]]$Endpoint
             namespace <- faasr$ComputeServers[[next_server]]$Namespace
             region <- faasr$ComputeServers[[next_server]]$Region
-            endpoint <- paste0(endpoint, namespace, "/locations/", region, "/jobs/faasrjob:run")
+            actionname <- invoke_next_function
+            endpoint <- paste0(endpoint, namespace, "/locations/", region, "/jobs/", actionname, ":run")
 
             token <- faasr$ComputeServers[[next_server]]$AccessKey
 

--- a/R/faasr_trigger.R
+++ b/R/faasr_trigger.R
@@ -100,18 +100,27 @@ faasr_trigger <- function(faasr) {
 
             # Prepare the args from the faasr object
             args <- toJSON(faasr, auto_unbox = TRUE)
-            # Build the body for the HTTP request without specifying the image
+            
+            #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+            # Base64 encode the JSON payload before sending
+            library(base64enc)
+            encoded_args <- base64encode(charToRaw(args))
+            #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+            # Build the body for the HTTP request, using the encoded payload
             body <- list(
               overrides = list(
                 containerOverrides = list(
                   list(
-                    args = args
+                    # Use the new encoded string here
+                    args = encoded_args
                   )
                 )
                 # taskCount = 1, (Can be set if needed)
                 # timeout = paste0(service_timeout_seconds, "s")  # Set service timeout
               )
             )
+
             # Send the REST request (POST/GET/PUT/PATCH)
             response <- POST(
               url = endpoint,

--- a/schema/FaaSr.schema.json
+++ b/schema/FaaSr.schema.json
@@ -75,6 +75,15 @@
           "allOf":[
             {
               "if": {
+                "properties": {"FaaSType":{"const": "GoogleCloud"}},
+                "required":["FaaSType"]
+              },
+              "then": {
+                "required":["Namespace", "AccessKey", "Region"]
+              }
+            },
+            {
+              "if": {
                 "properties": {"FaaSType":{"const": "OpenWhisk"}},
                 "required":["FaaSType"]
               },

--- a/schema/FaaSr.schema.json
+++ b/schema/FaaSr.schema.json
@@ -58,7 +58,7 @@
         "":{
           "type":"object",
           "properties":{
-            "FaaSType":{"enum":["OpenWhisk", "GitHubActions", "Lambda"]},
+            "FaaSType":{"enum":["OpenWhisk", "GitHubActions", "Lambda", "GoogleCloud"]},
             "Region":{"type":"string","minLength": 1},
             "Endpoint":{"type":"string","minLength": 1},
             "Namespace":{"type":"string","minLength": 1},

--- a/schema/FaaSr.schema.json
+++ b/schema/FaaSr.schema.json
@@ -61,11 +61,13 @@
             "FaaSType":{"enum":["OpenWhisk", "GitHubActions", "Lambda", "GoogleCloud"]},
             "Region":{"type":"string","minLength": 1},
             "Endpoint":{"type":"string","minLength": 1},
+            "SchedulerEndpoint":{"type":"string","minLength": 1},
             "Namespace":{"type":"string","minLength": 1},
             "API.key":{"type":"string","minLength": 1},
             "AccessKey":{"type":"string","minLength": 1},
             "SecretKey":{"type":"string","minLength": 1},
-            "ServiceAccount":{"type":"string","minLength": 1},
+            "ClientEmail":{"type":"string","minLength": 1},
+            "TokenUri":{"type":"string","minLength": 1},
             "UserName":{"type":"string","minLenght": 1},
             "ActionRepoName":{"type":"string","minLenght": 1},            
             "Token":{"type":"string","minLength": 1},
@@ -80,7 +82,7 @@
                 "required":["FaaSType"]
               },
               "then": {
-                "required":["Namespace", "AccessKey", "Region", "ServiceAccount"]
+                "required":["Namespace", "SecretKey", "ClientEmail", "TokenUri", "Region"]
               }
             },
             {

--- a/schema/FaaSr.schema.json
+++ b/schema/FaaSr.schema.json
@@ -65,6 +65,7 @@
             "API.key":{"type":"string","minLength": 1},
             "AccessKey":{"type":"string","minLength": 1},
             "SecretKey":{"type":"string","minLength": 1},
+            "ServiceAccount":{"type":"string","minLength": 1},
             "UserName":{"type":"string","minLenght": 1},
             "ActionRepoName":{"type":"string","minLenght": 1},            
             "Token":{"type":"string","minLength": 1},
@@ -79,7 +80,7 @@
                 "required":["FaaSType"]
               },
               "then": {
-                "required":["Namespace", "AccessKey", "Region"]
+                "required":["Namespace", "AccessKey", "Region", "ServiceAccount"]
               }
             },
             {


### PR DESCRIPTION
- Implemented task execution through Cloud Run Jobs.
- Configured Google Cloud Scheduler to manage cron-based triggers.
- Expanded the FaaSr platform to support GCP deployments.